### PR TITLE
fix: harden ChatGPT app boundaries

### DIFF
--- a/apps-sdk/register.mjs
+++ b/apps-sdk/register.mjs
@@ -129,7 +129,6 @@ export function buildWidgetCsp(
     redirectDomains.push(...EXPLORER_ORIGINS);
   } else if (templateUri === X402_WIDGET_URIS.pricing) {
     resourceDomains.push('https://api.dexter.cash');
-    redirectDomains.push(...EXPLORER_ORIGINS);
   } else if (templateUri === X402_WIDGET_URIS.wallet) {
     // The visible wallet uses short-lived _meta capabilities for refresh and
     // the same-origin card-summary frame rail. No card tool is exposed.

--- a/apps-sdk/ui/src/components/pricing/ResourceIdentity.tsx
+++ b/apps-sdk/ui/src/components/pricing/ResourceIdentity.tsx
@@ -1,5 +1,7 @@
+import { useMemo, useState } from 'react';
 import type { EnrichedResource } from './types';
 import { formatHitCount } from './types';
+import { providerImageSources } from '../x402/providerImage';
 
 interface Props {
   resource: EnrichedResource | null;
@@ -28,7 +30,17 @@ export function ResourceIdentity({ resource, fallbackUrl, resourceRef }: Props) 
     descriptionFrom(resourceRef) ||
     'Unknown endpoint';
   const meta = buildMetaLine(resource, refUrl);
-  const icon = resource?.icon_url || null;
+  const sources = useMemo(() => providerImageSources({
+    iconUrl: resource?.icon_url,
+    resourceUrl: resource?.resource_url || refUrl,
+  }), [resource?.icon_url, resource?.resource_url, refUrl]);
+  const sourceKey = sources.join('\n');
+  const [loadState, setLoadState] = useState({
+    sourceKey: '',
+    attempt: 0,
+  });
+  const attempt = loadState.sourceKey === sourceKey ? loadState.attempt : 0;
+  const icon = sources[attempt] || null;
 
   return (
     <div className="dx-pricing__identity">
@@ -42,6 +54,15 @@ export function ResourceIdentity({ resource, fallbackUrl, resourceRef }: Props) 
             className="dx-pricing__identity-icon-img"
             aria-hidden
             loading="lazy"
+            onError={() => {
+              setLoadState((current) => ({
+                sourceKey,
+                attempt:
+                  current.sourceKey === sourceKey
+                    ? current.attempt + 1
+                    : 1,
+              }));
+            }}
           />
         ) : (
           <div className="dx-pricing__identity-icon-placeholder" aria-hidden />

--- a/apps-sdk/ui/src/components/x402/providerImage.ts
+++ b/apps-sdk/ui/src/components/x402/providerImage.ts
@@ -1,0 +1,63 @@
+const IMAGE_PROXY_URL = 'https://api.dexter.cash/api/img';
+const FAVICON_PROXY_URL = 'https://dexter.cash/api/favicon';
+
+function externalHttpUrl(value: string | null | undefined): URL | null {
+  if (typeof value !== 'string' || value.trim().length === 0) return null;
+  try {
+    const parsed = new URL(value.trim());
+    if (
+      !['http:', 'https:'].includes(parsed.protocol)
+      || parsed.username.length > 0
+      || parsed.password.length > 0
+      || parsed.hostname.length === 0
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function proxyProviderImageUrl(
+  value: string | null | undefined,
+): string | null {
+  const parsed = externalHttpUrl(value);
+  if (!parsed) return null;
+
+  if (
+    parsed.protocol === 'https:'
+    && parsed.origin === 'https://api.dexter.cash'
+    && parsed.pathname === '/api/img'
+  ) {
+    return parsed.href;
+  }
+
+  return `${IMAGE_PROXY_URL}?url=${encodeURIComponent(parsed.href)}`;
+}
+
+export function providerFaviconUrl(
+  resourceUrl: string | null | undefined,
+): string | null {
+  const parsed = externalHttpUrl(resourceUrl);
+  if (!parsed) return null;
+  return `${FAVICON_PROXY_URL}?domain=${encodeURIComponent(parsed.hostname)}`;
+}
+
+export function providerImageSources({
+  iconUrl,
+  logoUrl,
+  resourceUrl,
+}: {
+  iconUrl?: string | null;
+  logoUrl?: string | null;
+  resourceUrl?: string | null;
+}): string[] {
+  const sources = [
+    proxyProviderImageUrl(iconUrl),
+    proxyProviderImageUrl(logoUrl),
+    providerFaviconUrl(resourceUrl),
+  ].filter((value): value is string => Boolean(value));
+
+  return [...new Set(sources)];
+}

--- a/apps-sdk/ui/src/components/x402/search/SearchIdentityIcon.tsx
+++ b/apps-sdk/ui/src/components/x402/search/SearchIdentityIcon.tsx
@@ -1,22 +1,22 @@
 import { useMemo, useState } from 'react';
 import type { SearchResource } from './types';
-import { resourceIconUrl } from './utils';
+import { providerImageSources } from '../providerImage';
 
 /**
- * Identity icon: tries the resource's own icon → seller logo → favicon proxy
- * → a quiet geometric "unsigned" mark. No letter bubbles. Letter fallbacks
+ * Identity icon: tries Dexter-proxied provider art → Dexter favicon proxy →
+ * a quiet geometric "unsigned" mark. No arbitrary provider URL is requested
+ * by the browser. No letter bubbles. Letter fallbacks
  * read as tacky contacts-app filler; a small geometric glyph reads as
  * "we don't have art for this seller yet" without making each row look
  * like a different brand entirely.
  */
 export function SearchIdentityIcon({ resource, size = 44 }: { resource: SearchResource; size?: number }) {
   const sources = useMemo(() => {
-    const list: string[] = [];
-    if (resource.iconUrl) list.push(resource.iconUrl);
-    if (resource.sellerMeta?.logoUrl) list.push(resource.sellerMeta.logoUrl);
-    const proxied = resourceIconUrl(resource);
-    if (proxied && !list.includes(proxied)) list.push(proxied);
-    return list;
+    return providerImageSources({
+      iconUrl: resource.iconUrl,
+      logoUrl: resource.sellerMeta?.logoUrl,
+      resourceUrl: resource.url,
+    });
   }, [resource]);
 
   const sourceKey = sources.join('\n');

--- a/apps-sdk/ui/src/components/x402/search/utils.ts
+++ b/apps-sdk/ui/src/components/x402/search/utils.ts
@@ -1,4 +1,5 @@
 import type { SearchResource } from './types';
+import { providerImageSources } from '../providerImage';
 
 export function formatCompactNumber(value: number | null | undefined): string {
   if (value == null || Number.isNaN(value)) return '0';
@@ -26,13 +27,11 @@ export function hostLabel(url: string): string {
 }
 
 export function resourceIconUrl(resource: SearchResource): string {
-  if (resource.iconUrl) return resource.iconUrl;
-  try {
-    const hostname = new URL(resource.url).hostname;
-    return `https://dexter.cash/api/favicon?domain=${encodeURIComponent(hostname)}`;
-  } catch {
-    return resource.sellerMeta.logoUrl || '';
-  }
+  return providerImageSources({
+    iconUrl: resource.iconUrl,
+    logoUrl: resource.sellerMeta?.logoUrl,
+    resourceUrl: resource.url,
+  })[0] || '';
 }
 
 export function formatListedPrice(

--- a/lib/governed-asset-contract.mjs
+++ b/lib/governed-asset-contract.mjs
@@ -261,7 +261,7 @@ export const GOVERNED_ASSET_TOOL_CONTRACTS = Object.freeze({
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: true,
-      openWorldHint: true,
+      openWorldHint: false,
     },
   }),
   [GOVERNED_ASSET_TOOL_NAMES.execute]: descriptor({
@@ -292,12 +292,12 @@ export const GOVERNED_ASSET_TOOL_CONTRACTS = Object.freeze({
     operation: 'reconcile',
     title: 'Reconcile a Governed Asset Action',
     description:
-      'Request status-gated reconciliation for one exact intentId. It never creates a replacement intent, expands mandate scope, or automatically retries execution.',
+      'Request status-gated reconciliation for one exact intentId. Depending on the durable phase, Dexter may contact the facilitator or validator and may dispatch the already-signed transaction for that same attempt. It never creates a replacement intent, expands mandate scope, or retries execution as a new attempt. Never retry reconciliation automatically.',
     annotations: {
       readOnlyHint: false,
       destructiveHint: true,
       idempotentHint: true,
-      openWorldHint: false,
+      openWorldHint: true,
     },
   }),
   [GOVERNED_ASSET_TOOL_NAMES.history]: descriptor({

--- a/lib/open-session-resolution.mjs
+++ b/lib/open-session-resolution.mjs
@@ -125,48 +125,12 @@ export function createOpenSessionResolver({
     return null;
   }
 
-  async function resolveOrCreateSessionForWallet(args, extra) {
+  async function resolveOrCreateSessionForWallet(extra) {
     let sessionResolution = { mode: 'missing' };
-    let session = args?.sessionToken ? readOpenSessionHint(args.sessionToken) : readContextSessionHint(extra);
+    let session = readContextSessionHint(extra);
 
-    if (session && args?.sessionToken) {
-      linkSessionToContext(extra, args.sessionToken);
-      sessionResolution = { mode: 'resumed_from_token' };
-    } else if (session) {
+    if (session) {
       sessionResolution = { mode: 'resumed_from_context' };
-    }
-
-    if (!session && args?.sessionToken) {
-      const resolved = await resolveSessionByToken(args.sessionToken);
-      if (resolved) {
-        session = {
-          sessionId: resolved.sessionId,
-          sessionToken: args.sessionToken,
-          funding: resolved.funding || null,
-          expiresAt: resolved.expiresAt || null,
-        };
-        rememberOpenSessionHint({ ...session, ...resolved });
-        linkSessionToContext(extra, args.sessionToken);
-        sessionResolution = { mode: 'resumed_from_token' };
-      }
-    }
-
-    if (!session && args?.sessionToken) {
-      const isUuidFormat = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(args.sessionToken);
-      return {
-        session: null,
-        sessionResolution: {
-          mode: isUuidFormat ? 'invalid_token_format' : 'unknown_session_token',
-        },
-        error: {
-          error: isUuidFormat ? 'invalid_token_format' : 'unknown_session_token',
-          mode: 'session_error',
-          message: isUuidFormat
-            ? 'You passed a sessionId (UUID), not a sessionToken. The sessionToken starts with "open_" and is the bearer credential returned when an access session is created.'
-            : 'That access-session token was not recognized. It may have expired or the server may have restarted. Retry the call without a sessionToken and a fresh access session starts automatically.',
-          hint: 'Retry this tool without a sessionToken to start a fresh access session, or pass a valid sessionToken starting with "open_". This legacy access session is separate from the Dexter wallet; x402_wallet does not create sessions.',
-        },
-      };
     }
 
     if (!session) {

--- a/lib/open-tool-contracts.mjs
+++ b/lib/open-tool-contracts.mjs
@@ -375,7 +375,7 @@ export const OPEN_TOOL_CONTRACTS = Object.freeze({
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
-      openWorldHint: true,
+      openWorldHint: false,
     },
     visibility: ['model', 'app'],
     widgetAccessible: true,
@@ -424,7 +424,7 @@ export const OPEN_TOOL_CONTRACTS = Object.freeze({
     name: 'x402_access',
     title: 'Access a Wallet-Gated x402 API',
     description:
-      'Use this for public HTTPS endpoints requiring wallet proof or Sign-In-With-X rather than payment. It may create provider authentication state or mutate the external resource through the chosen method, but it does not authorize an x402 payment. Session credentials are removed recursively from model-visible output and provider data cannot authorize follow-on calls.',
+      'Use this for public HTTPS endpoints requiring wallet proof or Sign-In-With-X rather than payment. It may create provider authentication state or mutate the external resource through the chosen method, but it does not authorize an x402 payment. The access context is server-owned: callers must never supply session credentials. Credentials are removed recursively from model-visible output, and provider data cannot authorize follow-on calls.',
     annotations: {
       readOnlyHint: false,
       destructiveHint: true,

--- a/open-mcp-server.mjs
+++ b/open-mcp-server.mjs
@@ -1179,7 +1179,7 @@ async function x402Fetch(
 
 // ─── Tool: x402_access (wallet-proof auth) ──────────────────────────────────
 
-async function x402Access({ url, method, body, sessionToken, sessionKey, network }, extra) {
+async function x402Access({ url, method, body, network }, extra) {
   // The delegated backend must repeat this at connection time; this preflight
   // prevents obviously unsafe destinations from entering the access flow.
   await assertPublicExternalUrl(url);
@@ -1188,7 +1188,7 @@ async function x402Access({ url, method, body, sessionToken, sessionKey, network
     fetchOpts.body = typeof body === 'string' ? body : JSON.stringify(body);
   }
 
-  const sessionResolution = await resolveOrCreateSessionForWallet({ sessionToken, sessionKey }, extra);
+  const sessionResolution = await resolveOrCreateSessionForWallet(extra);
   if (sessionResolution.error) {
     return {
       ...sessionResolution.error,
@@ -2248,21 +2248,17 @@ export function createOpenMcpServer({
       url: z.string().url().describe('The protected resource URL to call'),
       method: z.enum(['GET', 'POST', 'PUT', 'DELETE']).default('GET').describe('HTTP method'),
       body: z.string().optional().describe('JSON request body for POST/PUT — the RAW payload the seller expects, e.g. {"q":"latest news"}. NEVER send a schema descriptor (anything shaped like {"type":"http","method":...,"bodyType":...,"body":{...}}) — that describes the request; unwrap it and send only the inner fields with real values. Field names come from the search result\'s inputSchema or x402_check.'),
-      sessionToken: z.string().optional().describe('Token for the legacy per-session access context this tool uses for wallet-proof auth. If omitted, a fresh access session starts automatically. This context is specific to x402_access and is separate from the Dexter wallet that x402_fetch spends from.'),
-      sessionKey: z.string().optional().describe('Optional stable key for reusing the same legacy access-session context across calls (for example, caller-hash on phone).'),
       network: z.string().optional().describe('Optional preferred auth network, e.g. solana:... or eip155:8453'),
     },
     _meta: ACCESS_META,
   }, async (args, extra) => {
     try {
       const result = await x402Access(args, extra);
-      const meta = { ...ACCESS_META };
       if (result.session?.sessionToken) {
-        meta.sessionToken = result.session.sessionToken;
         const { sessionToken: _drop, ...cleanSession } = result.session;
         result.session = cleanSession;
       }
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }], structuredContent: result, _meta: meta };
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }], structuredContent: result, _meta: ACCESS_META };
     } catch (err) {
       const data = { status: 500, error: err?.message || String(err) };
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }], structuredContent: data, isError: true, _meta: ACCESS_META };

--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -196,7 +196,7 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "idempotentHint": true,
-        "openWorldHint": true
+        "openWorldHint": false
       },
       "securitySchemes": [
         {
@@ -205,7 +205,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-marketplace-search-81fc7583",
+          "resourceUri": "ui://dexter/x402-marketplace-search-0b654c9b",
           "visibility": [
             "model",
             "app"
@@ -225,8 +225,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-marketplace-search-81fc7583",
-        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-81fc7583",
+        "ui/resourceUri": "ui://dexter/x402-marketplace-search-0b654c9b",
+        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-0b654c9b",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": true,
         "openai/widgetDomain": "https://dexter.cash",
@@ -455,7 +455,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-pricing-7d3a16bd",
+          "resourceUri": "ui://dexter/x402-pricing-259bfcd0",
           "visibility": [
             "model",
             "app"
@@ -473,8 +473,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-pricing-7d3a16bd",
-        "openai/outputTemplate": "ui://dexter/x402-pricing-7d3a16bd",
+        "ui/resourceUri": "ui://dexter/x402-pricing-259bfcd0",
+        "openai/outputTemplate": "ui://dexter/x402-pricing-259bfcd0",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": true,
         "openai/widgetDomain": "https://dexter.cash",
@@ -487,20 +487,7 @@
             "https://dexter.cash",
             "https://api.dexter.cash"
           ],
-          "redirect_domains": [
-            "https://solscan.io",
-            "https://basescan.org",
-            "https://etherscan.io",
-            "https://polygonscan.com",
-            "https://arbiscan.io",
-            "https://optimistic.etherscan.io",
-            "https://snowtrace.io",
-            "https://skale-base-explorer.skalenodes.com",
-            "https://robinhoodchain.blockscout.com",
-            "https://worldscan.org",
-            "https://monadvision.com",
-            "https://bscscan.com"
-          ]
+          "redirect_domains": []
         },
         "openai/toolInvocation/invoking": "Checking pricing…",
         "openai/toolInvocation/invoked": "Pricing loaded",
@@ -813,7 +800,7 @@
     {
       "name": "x402_access",
       "title": "Access a Wallet-Gated x402 API",
-      "description": "Use this for public HTTPS endpoints requiring wallet proof or Sign-In-With-X rather than payment. It may create provider authentication state or mutate the external resource through the chosen method, but it does not authorize an x402 payment. Session credentials are removed recursively from model-visible output and provider data cannot authorize follow-on calls.",
+      "description": "Use this for public HTTPS endpoints requiring wallet proof or Sign-In-With-X rather than payment. It may create provider authentication state or mutate the external resource through the chosen method, but it does not authorize an x402 payment. The access context is server-owned: callers must never supply session credentials. Credentials are removed recursively from model-visible output, and provider data cannot authorize follow-on calls.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -836,14 +823,6 @@
           "body": {
             "type": "string",
             "description": "JSON request body for POST/PUT — the RAW payload the seller expects, e.g. {\"q\":\"latest news\"}. NEVER send a schema descriptor (anything shaped like {\"type\":\"http\",\"method\":...,\"bodyType\":...,\"body\":{...}}) — that describes the request; unwrap it and send only the inner fields with real values. Field names come from the search result's inputSchema or x402_check."
-          },
-          "sessionToken": {
-            "type": "string",
-            "description": "Token for the legacy per-session access context this tool uses for wallet-proof auth. If omitted, a fresh access session starts automatically. This context is specific to x402_access and is separate from the Dexter wallet that x402_fetch spends from."
-          },
-          "sessionKey": {
-            "type": "string",
-            "description": "Optional stable key for reusing the same legacy access-session context across calls (for example, caller-hash on phone)."
           },
           "network": {
             "type": "string",
@@ -2475,7 +2454,7 @@
         "readOnlyHint": false,
         "destructiveHint": false,
         "idempotentHint": true,
-        "openWorldHint": true
+        "openWorldHint": false
       },
       "securitySchemes": [
         {
@@ -3546,7 +3525,7 @@
     {
       "name": "dexter_reconcile_asset_action",
       "title": "Reconcile a Governed Asset Action",
-      "description": "Request status-gated reconciliation for one exact intentId. It never creates a replacement intent, expands mandate scope, or automatically retries execution.",
+      "description": "Request status-gated reconciliation for one exact intentId. Depending on the durable phase, Dexter may contact the facilitator or validator and may dispatch the already-signed transaction for that same attempt. It never creates a replacement intent, expands mandate scope, or retries execution as a new attempt. Never retry reconciliation automatically.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -4227,7 +4206,7 @@
         "readOnlyHint": false,
         "destructiveHint": true,
         "idempotentHint": true,
-        "openWorldHint": false
+        "openWorldHint": true
       },
       "securitySchemes": [
         {

--- a/tests/apps-sdk-search-hosts.e2e.mjs
+++ b/tests/apps-sdk-search-hosts.e2e.mjs
@@ -14,15 +14,21 @@ const UI_ROOT = path.join(REPO_ROOT, 'apps-sdk', 'ui');
 const FIXED_NOW = '2026-07-25T12:34:00.000Z';
 const SCREENSHOT_DIR = '/tmp/dexter-search-host-harness';
 
-const ICON_DATA_URL = [
-  'data:image/svg+xml,',
-  encodeURIComponent(
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 44 44">'
-      + '<rect width="44" height="44" rx="12" fill="#f2681a"/>'
-      + '<circle cx="22" cy="22" r="8" fill="#fffdf9"/>'
-      + '</svg>',
-  ),
-].join('');
+const ATLAS_ICON_URL = 'https://icons.fixture.example/atlas.svg';
+const BEACON_ICON_URL = 'https://icons.fixture.example/beacon.svg';
+const BROKEN_ICON_URL = 'https://broken-provider.fixture/icon.svg';
+const BROKEN_LOGO_URL = 'https://broken-provider.fixture/logo.svg';
+const BROKEN_RESOURCE_URL = 'https://broken-provider.fixture/resource';
+const proxiedIconUrl = (url) =>
+  `https://api.dexter.cash/api/img?url=${encodeURIComponent(url)}`;
+const faviconUrl = (url) =>
+  `https://dexter.cash/api/favicon?domain=${encodeURIComponent(new URL(url).hostname)}`;
+const FIXED_WIDGET_IMAGE_URLS = new Set([
+  'https://dexter.cash/assets/chains/base.svg',
+  'https://dexter.cash/assets/chains/solana.svg',
+  'https://dexter.cash/wordmarks/dexter-wordmark.svg',
+  'https://x402gle.com/x-final-transparent.png',
+]);
 
 const SEARCH_OUTPUT = {
   success: true,
@@ -54,7 +60,7 @@ const SEARCH_OUTPUT = {
       qualityScore: 97,
       verified: true,
       totalCalls: 2401,
-      iconUrl: ICON_DATA_URL,
+      iconUrl: ATLAS_ICON_URL,
       seller: 'Atlas Labs',
       sellerMeta: {
         payTo: '0xatlas',
@@ -108,7 +114,7 @@ const SEARCH_OUTPUT = {
       qualityScore: 93,
       verified: true,
       totalCalls: 1904,
-      iconUrl: ICON_DATA_URL,
+      iconUrl: BEACON_ICON_URL,
       seller: 'Beacon Systems',
       sellerMeta: {
         payTo: '0xbeacon',
@@ -236,6 +242,21 @@ const EXACT_GET_CHECK_TOOL_RESULT = {
       method: 'GET',
       body: null,
       requestBound: true,
+    },
+    enrichment: {
+      resource: {
+        resource_url: 'https://fixture.example/atlas',
+        host: 'fixture.example',
+        display_name: 'Atlas Price Feed',
+        description: 'Fast market snapshots with source timestamps.',
+        category: 'market-data',
+        icon_url: ATLAS_ICON_URL,
+      },
+      history: {
+        count: 0,
+        recent: [],
+        summary: null,
+      },
     },
   },
   content: [
@@ -1118,7 +1139,39 @@ test('search widget completes the fresh-check flow in ChatGPT and MCP Apps hosts
       }
 
       if (route.request().resourceType() === 'image') {
+        const isDexterImageProxy =
+          requestUrl.origin === 'https://api.dexter.cash'
+          && requestUrl.pathname === '/api/img';
+        const isDexterFaviconProxy =
+          requestUrl.origin === 'https://dexter.cash'
+          && requestUrl.pathname === '/api/favicon';
+        const isFixedWidgetImage = FIXED_WIDGET_IMAGE_URLS.has(
+          route.request().url(),
+        );
+        if (
+          !isDexterImageProxy
+          && !isDexterFaviconProxy
+          && !isFixedWidgetImage
+        ) {
+          unexpectedExternalRequests.push(route.request().url());
+          await route.abort('blockedbyclient');
+          return;
+        }
         interceptedExternalImages.push(route.request().url());
+        const proxiedProviderUrl = isDexterImageProxy
+          ? requestUrl.searchParams.get('url')
+          : null;
+        const faviconDomain = isDexterFaviconProxy
+          ? requestUrl.searchParams.get('domain')
+          : null;
+        if (
+          proxiedProviderUrl === BROKEN_ICON_URL
+          || proxiedProviderUrl === BROKEN_LOGO_URL
+          || faviconDomain === new URL(BROKEN_RESOURCE_URL).hostname
+        ) {
+          await route.fulfill({ status: 404, body: '' });
+          return;
+        }
         await route.fulfill({
           status: 200,
           contentType: 'image/svg+xml',
@@ -1311,6 +1364,13 @@ test('search widget completes the fresh-check flow in ChatGPT and MCP Apps hosts
         allowDisplayMode: false,
       });
       await page.goto(pricingWidgetUrl);
+
+      const pricingIcon = page.locator('.dx-pricing__identity-icon-img');
+      await pricingIcon.waitFor();
+      assert.equal(
+        await pricingIcon.getAttribute('src'),
+        proxiedIconUrl(ATLAS_ICON_URL),
+      );
 
       const continueButton = page.getByRole(
         'button',
@@ -1539,7 +1599,9 @@ test('search widget completes the fresh-check flow in ChatGPT and MCP Apps hosts
 
     await t.test('service icon fallback resets when the hero changes', async () => {
       const iconOutput = structuredClone(SEARCH_OUTPUT);
-      iconOutput.strongResults[0].iconUrl = 'data:image/png;base64,invalid';
+      iconOutput.strongResults[0].iconUrl = BROKEN_ICON_URL;
+      iconOutput.strongResults[0].sellerMeta.logoUrl = BROKEN_LOGO_URL;
+      iconOutput.strongResults[0].url = BROKEN_RESOURCE_URL;
 
       const page = await context.newPage();
       await page.addInitScript(installChatGptHost, {
@@ -1552,12 +1614,25 @@ test('search widget completes the fresh-check flow in ChatGPT and MCP Apps hosts
       await page.locator(
         '.dx-search-brief__identity .dx-search-identity__unsigned',
       ).waitFor();
+      for (const expectedFailure of [
+        proxiedIconUrl(BROKEN_ICON_URL),
+        proxiedIconUrl(BROKEN_LOGO_URL),
+        faviconUrl(BROKEN_RESOURCE_URL),
+      ]) {
+        assert.ok(
+          interceptedExternalImages.includes(expectedFailure),
+          `Expected fallback attempt ${expectedFailure}`,
+        );
+      }
       await page.getByRole('button', { name: /Beacon Price Feed/ }).click();
       const heroIcon = page.locator(
         '.dx-search-brief__identity .dx-search-identity__img',
       );
       await heroIcon.waitFor();
-      assert.equal(await heroIcon.getAttribute('src'), ICON_DATA_URL);
+      assert.equal(
+        await heroIcon.getAttribute('src'),
+        proxiedIconUrl(BEACON_ICON_URL),
+      );
       await page.close();
     });
 
@@ -1672,6 +1747,17 @@ test('search widget completes the fresh-check flow in ChatGPT and MCP Apps hosts
     assert.ok(
       interceptedExternalImages.every((url) => /^https?:\/\//.test(url)),
       'Remote image references must be satisfied by deterministic in-memory fixtures',
+    );
+    assert.equal(
+      interceptedExternalImages.some((url) =>
+        new URL(url).hostname === 'icons.fixture.example'),
+      false,
+      'Widgets must never request arbitrary provider images directly',
+    );
+    assert.ok(
+      interceptedExternalImages.some((url) =>
+        url === proxiedIconUrl(ATLAS_ICON_URL)),
+      'Provider images must pass through the Dexter image proxy',
     );
     assert.deepEqual(
       unexpectedExternalRequests,

--- a/tests/governed-asset-contract.test.mjs
+++ b/tests/governed-asset-contract.test.mjs
@@ -208,6 +208,7 @@ test('operation identity never substitutes for authority or owner approval', () 
   });
   const prepare = GOVERNED_ASSET_TOOL_CONTRACTS.dexter_prepare_asset_action.description;
   const execute = GOVERNED_ASSET_TOOL_CONTRACTS.dexter_execute_asset_action.description;
+  const reconcile = GOVERNED_ASSET_TOOL_CONTRACTS.dexter_reconcile_asset_action.description;
   assert.match(prepare, /Idempotency-Key/);
   assert.match(prepare, /canonical assetId returned by dexter_portfolio/);
   assert.match(prepare, /approved holding or approvedActionTarget/);
@@ -220,4 +221,8 @@ test('operation identity never substitutes for authority or owner approval', () 
   assert.match(execute, /covered by the bound reusable mandate may execute autonomously/);
   assert.match(execute, /Never call Execute after protected_agent_send_sdk_required/);
   assert.match(execute, /Never retry automatically/);
+  assert.match(reconcile, /contact the facilitator or validator/);
+  assert.match(reconcile, /dispatch the already-signed transaction/);
+  assert.match(reconcile, /same attempt/);
+  assert.match(reconcile, /Never retry reconciliation automatically/);
 });

--- a/tests/open-session-resolution.test.mjs
+++ b/tests/open-session-resolution.test.mjs
@@ -37,3 +37,41 @@ test('server-owned SDK context and transport headers remain valid session source
     'transport-session',
   );
 });
+
+test('access sessions are created once and reused only through server-owned MCP context', async (t) => {
+  const originalFetch = globalThis.fetch;
+  const requests = [];
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = async (url, options = {}) => {
+    requests.push({
+      url: String(url),
+      body: JSON.parse(String(options.body)),
+    });
+    return new Response(JSON.stringify({
+      ok: true,
+      sessionId: 'internal-access-session',
+      sessionToken: 'open_server_owned_secret',
+      expiresAt: '2026-08-16T02:00:00.000Z',
+      funding: { mode: 'not_required' },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  const { resolveOrCreateSessionForWallet } = resolver();
+  const extra = { sessionId: 'server-owned-mcp-session' };
+  const first = await resolveOrCreateSessionForWallet(extra);
+  const second = await resolveOrCreateSessionForWallet(extra);
+
+  assert.equal(first.error, null);
+  assert.equal(first.sessionResolution.mode, 'created_new');
+  assert.equal(second.error, null);
+  assert.equal(second.sessionResolution.mode, 'resumed_from_context');
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].body.sessionKey, 'server-owned-mcp-session');
+  assert.equal(Object.hasOwn(requests[0].body, 'sessionToken'), false);
+});

--- a/tests/open-tool-contracts.test.mjs
+++ b/tests/open-tool-contracts.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
@@ -573,7 +574,12 @@ test('both supported registration APIs close after finalization', () => {
 });
 
 test('behavior annotations reflect the canonical twelve operations', () => {
-  assert.equal(OPEN_TOOL_CONTRACTS.x402_search.annotations.readOnlyHint, true);
+  assert.deepEqual(OPEN_TOOL_CONTRACTS.x402_search.annotations, {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  });
   assert.equal(OPEN_TOOL_CONTRACTS.x402_wallet.annotations.readOnlyHint, false);
   assert.equal(OPEN_TOOL_CONTRACTS.x402_wallet.annotations.idempotentHint, false);
   assert.equal(OPEN_TOOL_CONTRACTS.dexter_portfolio.annotations.readOnlyHint, true);
@@ -591,7 +597,7 @@ test('behavior annotations reflect the canonical twelve operations', () => {
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: true,
-      openWorldHint: true,
+      openWorldHint: false,
     },
   );
   assert.equal(
@@ -612,8 +618,39 @@ test('behavior annotations reflect the canonical twelve operations', () => {
       readOnlyHint: false,
       destructiveHint: true,
       idempotentHint: true,
-      openWorldHint: false,
+      openWorldHint: true,
     },
+  );
+});
+
+test('x402_access exposes no caller credential input or metadata side channel', () => {
+  const serverSource = readFileSync(
+    new URL('../open-mcp-server.mjs', import.meta.url),
+    'utf8',
+  );
+  const registrationStart = serverSource.indexOf(
+    "registerOpenTool(server, 'x402_access'",
+  );
+  const registrationEnd = serverSource.indexOf(
+    "registerOpenTool(server, 'x402_wallet'",
+    registrationStart,
+  );
+  assert.ok(registrationStart >= 0);
+  assert.ok(registrationEnd > registrationStart);
+  const accessRegistration = serverSource.slice(
+    registrationStart,
+    registrationEnd,
+  );
+
+  assert.doesNotMatch(accessRegistration, /sessionKey\s*:/);
+  assert.doesNotMatch(accessRegistration, /meta\.sessionToken\s*=/);
+  assert.match(
+    OPEN_TOOL_CONTRACTS.x402_access.description,
+    /access context is server-owned/i,
+  );
+  assert.match(
+    OPEN_TOOL_CONTRACTS.x402_access.description,
+    /must never supply session credentials/i,
   );
 });
 

--- a/tests/open-tool-descriptors.test.mjs
+++ b/tests/open-tool-descriptors.test.mjs
@@ -510,6 +510,35 @@ test('source materializer emits one deterministic full hosted descriptor', async
   }
 
   const search = descriptor.tools.find(({ name }) => name === 'x402_search');
+  const access = descriptor.tools.find(({ name }) => name === 'x402_access');
+  const prepare = descriptor.tools.find(
+    ({ name }) => name === 'dexter_prepare_asset_action',
+  );
+  const reconcile = descriptor.tools.find(
+    ({ name }) => name === 'dexter_reconcile_asset_action',
+  );
+  assert.deepEqual(search.annotations, {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  });
+  assert.deepEqual(prepare.annotations, {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  });
+  assert.deepEqual(reconcile.annotations, {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: true,
+  });
+  assert.deepEqual(
+    Object.keys(access.inputSchema.properties).sort(),
+    ['body', 'method', 'network', 'url'],
+  );
   assert.equal(search._meta['ui/resourceUri'], search._meta.ui.resourceUri);
   assert.equal(search._meta['openai/outputTemplate'], search._meta.ui.resourceUri);
   assert.equal(search._meta['openai/widgetDomain'], search._meta.ui.domain);

--- a/tests/provider-image-proxy.test.mjs
+++ b/tests/provider-image-proxy.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  providerFaviconUrl,
+  providerImageSources,
+  proxyProviderImageUrl,
+} from '../apps-sdk/ui/src/components/x402/providerImage.ts';
+
+test('provider images use only the Dexter image and favicon proxies', () => {
+  assert.deepEqual(providerImageSources({
+    iconUrl: 'https://icons.provider.example/service.svg?size=44',
+    logoUrl: 'https://seller.example/logo.png',
+    resourceUrl: 'https://api.seller.example/v1/price?asset=SOL',
+  }), [
+    'https://api.dexter.cash/api/img?url=https%3A%2F%2Ficons.provider.example%2Fservice.svg%3Fsize%3D44',
+    'https://api.dexter.cash/api/img?url=https%3A%2F%2Fseller.example%2Flogo.png',
+    'https://dexter.cash/api/favicon?domain=api.seller.example',
+  ]);
+});
+
+test('provider image helpers reject executable, embedded, credentialed, and malformed URLs', () => {
+  for (const value of [
+    'data:image/png;base64,abc',
+    'javascript:alert(1)',
+    'file:///etc/passwd',
+    'https://user:secret@example.com/icon.png',
+    'not a URL',
+    '',
+    null,
+  ]) {
+    assert.equal(proxyProviderImageUrl(value), null, String(value));
+  }
+  assert.equal(providerFaviconUrl('javascript:alert(1)'), null);
+  assert.deepEqual(providerImageSources({
+    iconUrl: 'data:image/png;base64,abc',
+    resourceUrl: 'not a URL',
+  }), []);
+});
+
+test('an existing canonical Dexter image proxy URL is not wrapped twice', () => {
+  const existing =
+    'https://api.dexter.cash/api/img?url=https%3A%2F%2Fprovider.example%2Ficon.png';
+  assert.equal(proxyProviderImageUrl(existing), existing);
+});

--- a/tests/widget-resource-metadata.test.mjs
+++ b/tests/widget-resource-metadata.test.mjs
@@ -93,6 +93,19 @@ test('resource profiles grant only widget-specific network capabilities', () => 
   assert.ok(search.resource_domains.includes('https://x402gle.com'));
   assert.ok(!search.resource_domains.includes('https://api.qrserver.com'));
 
+  const pricing = buildWidgetCsp(
+    'https://dexter.cash/assets',
+    X402_WIDGET_URIS.pricing,
+  );
+  assert.ok(pricing.resource_domains.includes('https://api.dexter.cash'));
+  assert.deepEqual(pricing.redirect_domains, []);
+
+  const receipt = buildWidgetCsp(
+    'https://dexter.cash/assets',
+    X402_WIDGET_URIS.fetch,
+  );
+  assert.ok(receipt.redirect_domains.includes('https://solscan.io'));
+
   const wallet = buildWidgetCsp('https://dexter.cash/assets', X402_WIDGET_URIS.wallet);
   assert.ok(wallet.connect_domains.includes('https://open.dexter.cash'));
   assert.ok(wallet.resource_domains.includes('https://open.dexter.cash'));


### PR DESCRIPTION
## Outcome

Prepares the hosted OpenDexter ChatGPT app for a safe combined-plugin test:

- removes caller-supplied access-session credentials and keeps continuity server-owned
- corrects tool read/write/open-world metadata and discloses reconciliation consequences
- proxies provider images through Dexter-owned endpoints with strict URL filtering and real fallback behavior
- removes unused pricing-widget redirect permissions
- regenerates the hosted descriptor from the finalized SDK tool list

## Verification

- focused contracts: 60/60
- real ChatGPT/MCP Apps browser harness: 16/16
- broader auth/spend/money/source contracts: 46/46
- provider image and widget metadata: 8/8
- open-release TypeScript check: passed
- isolated production widget build: passed
- strict clean-archive descriptor verification: passed
- independent source, security, widget, and generated-descriptor review: SHIP; no P0-P2

No production runtime, database, payment, wallet, or plugin-install mutation is included.