### PR TITLE
chore: pin hosted OpenDexter x402 rc3 train

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       "dependencies": {
         "@dexterai/mcp-instructions": "2.4.1",
         "@dexterai/vault": "0.43.2",
-        "@dexterai/x402": "6.0.0-rc.2",
+        "@dexterai/x402": "6.0.0-rc.3",
         "@dexterai/x402-core": "1.5.2",
-        "@dexterai/x402-mcp-tools": "0.9.0-rc.0",
+        "@dexterai/x402-mcp-tools": "0.9.0-rc.1",
         "@dexterai/x402-skills": "file:./packages/x402-skills",
         "@modelcontextprotocol/ext-apps": "1.6.0",
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -437,9 +437,9 @@
       }
     },
     "node_modules/@dexterai/x402": {
-      "version": "6.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.2.tgz",
-      "integrity": "sha512-JnLDEC6pAf6UIV2vaXtIPT5LcEyzKvfwGopZGjVFIzs8LBwG1wgvxQ+hD4K5WRhMryUkPPr4EUN0TasIFs9krQ==",
+      "version": "6.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.3.tgz",
+      "integrity": "sha512-rwGysJ03gPVzr+Xl8EiO6rt12K6fHWkm7Tiw1t9JJzGZQcCads+jxruPYjn7CBWleUR+SQItZ2XZ8N6had1JCw==",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",
@@ -494,14 +494,14 @@
       "link": true
     },
     "node_modules/@dexterai/x402-mcp-tools": {
-      "version": "0.9.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@dexterai/x402-mcp-tools/-/x402-mcp-tools-0.9.0-rc.0.tgz",
-      "integrity": "sha512-kARs5sKDFWMcLoBujeyq8a1zNpMjRQooTpTAdiHpqDFhmGe2SQ80BC//ITxlXiDgVtdck+Mzo9RSI7axSfT+rg==",
+      "version": "0.9.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@dexterai/x402-mcp-tools/-/x402-mcp-tools-0.9.0-rc.1.tgz",
+      "integrity": "sha512-SisZigkBz5XuKdA6MHNXaoFmF6LwITpcjkH4MeGU7zeJ9A5EnA6HKvaRFxzzvqE/vi4RMBO7Hty4+G5A0309DA==",
       "license": "MIT",
       "dependencies": {
         "@dexterai/dextercard": "^0.5.0",
         "@dexterai/vault": "0.43.2",
-        "@dexterai/x402": "6.0.0-rc.2",
+        "@dexterai/x402": "6.0.0-rc.3",
         "@dexterai/x402-core": "1.5.2",
         "@modelcontextprotocol/sdk": "^1.17.4",
         "@x402/core": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "dependencies": {
     "@dexterai/mcp-instructions": "2.4.1",
     "@dexterai/vault": "0.43.2",
-    "@dexterai/x402": "6.0.0-rc.2",
+    "@dexterai/x402": "6.0.0-rc.3",
     "@dexterai/x402-core": "1.5.2",
-    "@dexterai/x402-mcp-tools": "0.9.0-rc.0",
+    "@dexterai/x402-mcp-tools": "0.9.0-rc.1",
     "@dexterai/x402-skills": "file:./packages/x402-skills",
     "@modelcontextprotocol/ext-apps": "1.6.0",
     "@modelcontextprotocol/sdk": "1.29.0",

--- a/release/opendexter-dependency-train.json
+++ b/release/opendexter-dependency-train.json
@@ -13,9 +13,9 @@
     },
     "opendexter-ide": {
       "remote": "https://github.com/Dexter-DAO/opendexter-ide.git",
-      "provenanceCommit": "69a304652483049c637e2c389663c10255d6b916",
+      "provenanceCommit": "d0af97fdff2638042626720e5e69c26d4e7d2ffe",
       "rootWorkspaceBuild": {
-        "packageLockSha256": "da06803ef1b745964834c7432c38d276dd29cd2c57fa92f0290b826816bb8d05",
+        "packageLockSha256": "0d59c0ccaa147e852586a4c0e9e15af4aea8de36042b63a0a0371c06c0c39c45",
         "buildOrder": [
           {
             "workspace": "@dexterai/mcp-instructions",
@@ -76,21 +76,21 @@
     },
     {
       "name": "@dexterai/x402-mcp-tools",
-      "version": "0.9.0-rc.0",
-      "rootSpecifier": "0.9.0-rc.0",
+      "version": "0.9.0-rc.1",
+      "rootSpecifier": "0.9.0-rc.1",
       "source": "opendexter-ide",
       "path": "packages/x402-mcp-tools",
       "entrypoint": "dist/index.js",
-      "treeHash": "8219c6dc6dd85e3957725d40c8afd088643334a5",
+      "treeHash": "aff991cc7f3ad562b28e2c1b65f5da17f9fda8c5",
       "packedArtifact": {
         "buildMode": "root-workspace",
         "buildScript": "build",
-        "integrity": "sha512-kARs5sKDFWMcLoBujeyq8a1zNpMjRQooTpTAdiHpqDFhmGe2SQ80BC//ITxlXiDgVtdck+Mzo9RSI7axSfT+rg==",
-        "shasum": "25885e4406070983da38018ed49370c9decb31f6",
-        "size": 70351,
+        "integrity": "sha512-SisZigkBz5XuKdA6MHNXaoFmF6LwITpcjkH4MeGU7zeJ9A5EnA6HKvaRFxzzvqE/vi4RMBO7Hty4+G5A0309DA==",
+        "shasum": "54a3ed095fa123ae5f09e01239887c52e099d2e0",
+        "size": 70360,
         "unpackedSize": 284248,
         "entryCount": 21,
-        "tgzSha256": "b334ff52b29391f6a634c735d05e350fca7b61fd6debdd202e8b096da32ced83"
+        "tgzSha256": "97a132871d8cd1e0e32446ea3b3d7b1afe41a6a0b89fc98d75173f2a48f313a0"
       },
       "install": {
         "source": "linked-source",
@@ -125,8 +125,8 @@
   "runtimePackages": [
     {
       "name": "@dexterai/x402",
-      "version": "6.0.0-rc.2",
-      "rootSpecifier": "6.0.0-rc.2"
+      "version": "6.0.0-rc.3",
+      "rootSpecifier": "6.0.0-rc.3"
     },
     {
       "name": "@modelcontextprotocol/sdk",

--- a/tests/open-mcp-manifest.test.mjs
+++ b/tests/open-mcp-manifest.test.mjs
@@ -82,7 +82,7 @@ test('manifest, server identity, and package use one release version', async () 
   );
   assert.equal(
     packageJson.dependencies['@dexterai/x402-mcp-tools'],
-    '0.9.0-rc.0',
+    '0.9.0-rc.1',
   );
   assert.equal(
     packageJson.dependencies['@modelcontextprotocol/sdk'],

--- a/tests/open-release-dependencies.test.mjs
+++ b/tests/open-release-dependencies.test.mjs
@@ -365,7 +365,7 @@ test('hosted source declares one exact internal dependency train', async () => {
     [
       '@dexterai/x402-core@1.5.2',
       '@dexterai/mcp-instructions@2.4.1',
-      '@dexterai/x402-mcp-tools@0.9.0-rc.0',
+      '@dexterai/x402-mcp-tools@0.9.0-rc.1',
       '@dexterai/vault@0.43.2',
     ],
   );
@@ -373,7 +373,7 @@ test('hosted source declares one exact internal dependency train', async () => {
     manifest.runtimePackages.map(({ name, version }) =>
       `${name}@${version}`),
     [
-      '@dexterai/x402@6.0.0-rc.2',
+      '@dexterai/x402@6.0.0-rc.3',
       '@modelcontextprotocol/sdk@1.29.0',
       '@modelcontextprotocol/ext-apps@1.6.0',
       'zod@3.25.76',
@@ -397,10 +397,10 @@ test('hosted source declares one exact internal dependency train', async () => {
   );
   assert.deepEqual(manifest.repositories['opendexter-ide'], {
     remote: 'https://github.com/Dexter-DAO/opendexter-ide.git',
-    provenanceCommit: '69a304652483049c637e2c389663c10255d6b916',
+    provenanceCommit: 'd0af97fdff2638042626720e5e69c26d4e7d2ffe',
     rootWorkspaceBuild: {
       packageLockSha256:
-        'da06803ef1b745964834c7432c38d276dd29cd2c57fa92f0290b826816bb8d05',
+        '0d59c0ccaa147e852586a4c0e9e15af4aea8de36042b63a0a0371c06c0c39c45',
       buildOrder: [
         { workspace: '@dexterai/mcp-instructions', script: 'build' },
         { workspace: '@dexterai/dextercard', script: 'build' },
@@ -415,7 +415,7 @@ test('hosted source declares one exact internal dependency train', async () => {
     ],
     [
       '@dexterai/x402-mcp-tools',
-      'b334ff52b29391f6a634c735d05e350fca7b61fd6debdd202e8b096da32ced83',
+      '97a132871d8cd1e0e32446ea3b3d7b1afe41a6a0b89fc98d75173f2a48f313a0',
     ],
   ]) {
     const artifact = manifest.sourcePackages.find(


### PR DESCRIPTION
## Summary
- pin hosted OpenDexter to `@dexterai/x402@6.0.0-rc.3`
- pin `@dexterai/x402-mcp-tools@0.9.0-rc.1`
- refresh the exact registry lock and source/artifact provenance to OpenDexter source `d0af97f`
- preserve the current hosted accepted-production receipt and generated descriptors byte-for-byte

## Package evidence
- tools registry tgz SHA256: `97a132871d8cd1e0e32446ea3b3d7b1afe41a6a0b89fc98d75173f2a48f313a0`
- tools integrity: `sha512-SisZigkBz5XuKdA6MHNXaoFmF6LwITpcjkH4MeGU7zeJ9A5EnA6HKvaRFxzzvqE/vi4RMBO7Hty4+G5A0309DA==`
- x402 rc.3 tgz SHA256: `fce38132396bd4bda5b8de69e2c7c8d40dd3f7b5efb923efc3ecdb6f143bb973`

## Verification
- runtime, exact registry lock, and installed graph gates pass
- dependency/manifest/inventory tests: 35 pass, 1 source fixture skipped
- full raw Node suite with release umask: 595 pass, 1 skip
- strict open-release typecheck passes

## Safety
- source-only; no PM2 or live deployment mutation
- no accepted-production receipt, descriptor regeneration, or release build
- fresh acceptance remains gated on live API `6c243` plus the compatible facilitator