### PR TITLE
fix: bind hosted contract to live API

### DIFF
--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -6,11 +6,11 @@
     "kind": "opendexter-source-contracts/v3",
     "api": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
-      "tree": "b8a3bdd790379f82b959663e679960f213addb5b",
+      "commit": "6c243154e9e06f4e40830300c4027721645a33cc",
+      "tree": "ce2976ada70af9234291aa6a472b3d96a7a84989",
       "consumerFixture": {
-        "path": "tests/fixtures/governed-agent-reconcile-advanced-final-c3e32885.json",
-        "sha256": "449fc6b5a253d6856ae9f0990932dc6cefb84871c981229afb603a6314efa798",
+        "path": "tests/fixtures/governed-agent-reconcile-advanced-final-6c243154.json",
+        "sha256": "ce947da8dbc22b602d5254949787b777b66095bb2530a707fb1db6d73b1b41d4",
         "canonicalBodyDigest": "48e77a936f06fe07b66fee7c2cb9126e8305d4e180c2c304513d5f0ea1636e16"
       }
     },
@@ -18,8 +18,8 @@
       "repository": "https://github.com/Dexter-DAO/dexter-api",
       "commit": "6c243154e9e06f4e40830300c4027721645a33cc",
       "tree": "ce2976ada70af9234291aa6a472b3d96a7a84989",
-      "governedContractCommit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
-      "governedContractTree": "b8a3bdd790379f82b959663e679960f213addb5b"
+      "governedContractCommit": "6c243154e9e06f4e40830300c4027721645a33cc",
+      "governedContractTree": "ce2976ada70af9234291aa6a472b3d96a7a84989"
     },
     "portfolioProjection": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",

--- a/release/opendexter-source-contracts.json
+++ b/release/opendexter-source-contracts.json
@@ -3,11 +3,11 @@
   "kind": "opendexter-source-contracts/v3",
   "api": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
-    "tree": "b8a3bdd790379f82b959663e679960f213addb5b",
+    "commit": "6c243154e9e06f4e40830300c4027721645a33cc",
+    "tree": "ce2976ada70af9234291aa6a472b3d96a7a84989",
     "consumerFixture": {
-      "path": "tests/fixtures/governed-agent-reconcile-advanced-final-c3e32885.json",
-      "sha256": "449fc6b5a253d6856ae9f0990932dc6cefb84871c981229afb603a6314efa798",
+      "path": "tests/fixtures/governed-agent-reconcile-advanced-final-6c243154.json",
+      "sha256": "ce947da8dbc22b602d5254949787b777b66095bb2530a707fb1db6d73b1b41d4",
       "canonicalBodyDigest": "48e77a936f06fe07b66fee7c2cb9126e8305d4e180c2c304513d5f0ea1636e16"
     }
   },
@@ -15,8 +15,8 @@
     "repository": "https://github.com/Dexter-DAO/dexter-api",
     "commit": "6c243154e9e06f4e40830300c4027721645a33cc",
     "tree": "ce2976ada70af9234291aa6a472b3d96a7a84989",
-    "governedContractCommit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
-    "governedContractTree": "b8a3bdd790379f82b959663e679960f213addb5b"
+    "governedContractCommit": "6c243154e9e06f4e40830300c4027721645a33cc",
+    "governedContractTree": "ce2976ada70af9234291aa6a472b3d96a7a84989"
   },
   "portfolioProjection": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",

--- a/scripts/materialize-open-tool-descriptors.mjs
+++ b/scripts/materialize-open-tool-descriptors.mjs
@@ -84,7 +84,7 @@ const SOURCE_CONTRACTS_RELATIVE_PATH =
 const DESCRIPTOR_RELATIVE_PATH =
   'release/open-tool-descriptors.json';
 const RECONCILE_FIXTURE_PATH =
-  'tests/fixtures/governed-agent-reconcile-advanced-final-c3e32885.json';
+  'tests/fixtures/governed-agent-reconcile-advanced-final-6c243154.json';
 const BINDING_FIXTURE_CONSUMER_PATH =
   'tests/fixtures/governed-agent-trade-api-facilitator-binding-v1.json';
 const BINDING_FIXTURE_API_PATH =
@@ -105,10 +105,10 @@ const API_GOVERNED_CONTRACT_PATHS = Object.freeze([
 ]);
 
 const EXPECTED_SOURCE_CONTRACTS = Object.freeze({
-  apiCommit: 'c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b',
-  apiTree: 'b8a3bdd790379f82b959663e679960f213addb5b',
+  apiCommit: '6c243154e9e06f4e40830300c4027721645a33cc',
+  apiTree: 'ce2976ada70af9234291aa6a472b3d96a7a84989',
   apiFixtureSha256:
-    '449fc6b5a253d6856ae9f0990932dc6cefb84871c981229afb603a6314efa798',
+    'ce947da8dbc22b602d5254949787b777b66095bb2530a707fb1db6d73b1b41d4',
   apiCanonicalBodyDigest:
     '48e77a936f06fe07b66fee7c2cb9126e8305d4e180c2c304513d5f0ea1636e16',
   portfolioProjectionFixtureSha256:

--- a/tests/fixtures/governed-agent-reconcile-advanced-final-6c243154.json
+++ b/tests/fixtures/governed-agent-reconcile-advanced-final-6c243154.json
@@ -1,6 +1,6 @@
 {
   "sourceRepository": "Dexter-DAO/dexter-api",
-  "sourceCommit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
+  "sourceCommit": "6c243154e9e06f4e40830300c4027721645a33cc",
   "httpStatus": 200,
   "input": {
     "intentId": "419f981c-9215-4141-84f2-d89ffe9cbece"

--- a/tests/governed-asset-client.test.mjs
+++ b/tests/governed-asset-client.test.mjs
@@ -43,12 +43,12 @@ const NOW = 1_785_020_400_000;
 const ADDRESS = '11111111111111111111111111111111';
 const PREPARE_PATH =
   '/api/passkey-vault/governed-assets/agent/actions/prepare';
-const API_C3_ADVANCED_FINAL_FIXTURE_BYTES = readFileSync(new URL(
-  './fixtures/governed-agent-reconcile-advanced-final-c3e32885.json',
+const API_6C243_ADVANCED_FINAL_FIXTURE_BYTES = readFileSync(new URL(
+  './fixtures/governed-agent-reconcile-advanced-final-6c243154.json',
   import.meta.url,
 ));
-const API_C3_ADVANCED_FINAL_FIXTURE = JSON.parse(
-  API_C3_ADVANCED_FINAL_FIXTURE_BYTES.toString('utf8'),
+const API_6C243_ADVANCED_FINAL_FIXTURE = JSON.parse(
+  API_6C243_ADVANCED_FINAL_FIXTURE_BYTES.toString('utf8'),
 );
 
 function jsonResponse(status, body, headers = {}) {
@@ -1128,20 +1128,20 @@ test('reconcile accepts every exact runtime outcome envelope', async () => {
   }
 });
 
-test('reconcile accepts the exact API c3 advanced-final public envelope', async () => {
+test('reconcile accepts the exact API 6c243 advanced-final public envelope', async () => {
   assert.equal(
     createHash('sha256')
-      .update(API_C3_ADVANCED_FINAL_FIXTURE_BYTES)
+      .update(API_6C243_ADVANCED_FINAL_FIXTURE_BYTES)
       .digest('hex'),
-    '449fc6b5a253d6856ae9f0990932dc6cefb84871c981229afb603a6314efa798',
+    'ce947da8dbc22b602d5254949787b777b66095bb2530a707fb1db6d73b1b41d4',
   );
   assert.equal(
-    API_C3_ADVANCED_FINAL_FIXTURE.sourceCommit,
-    'c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b',
+    API_6C243_ADVANCED_FINAL_FIXTURE.sourceCommit,
+    '6c243154e9e06f4e40830300c4027721645a33cc',
   );
   assert.equal(
     GOVERNED_ASSET_TOOL_OUTPUT_SCHEMAS.reconcile.safeParse(
-      API_C3_ADVANCED_FINAL_FIXTURE.body,
+      API_6C243_ADVANCED_FINAL_FIXTURE.body,
     ).success,
     true,
   );
@@ -1150,21 +1150,21 @@ test('reconcile accepts the exact API c3 advanced-final public envelope', async 
     apiBase: 'https://api.dexter.test',
     secret: SECRET,
     operation: 'reconcile',
-    input: API_C3_ADVANCED_FINAL_FIXTURE.input,
+    input: API_6C243_ADVANCED_FINAL_FIXTURE.input,
     mcpSessionId: SESSION_ID,
     now: NOW,
     fetchImpl: async () => jsonResponse(
-      API_C3_ADVANCED_FINAL_FIXTURE.httpStatus,
-      API_C3_ADVANCED_FINAL_FIXTURE.body,
+      API_6C243_ADVANCED_FINAL_FIXTURE.httpStatus,
+      API_6C243_ADVANCED_FINAL_FIXTURE.body,
     ),
   });
 
   assert.equal(result.isError, false);
-  assert.deepEqual(result.body, API_C3_ADVANCED_FINAL_FIXTURE.body);
+  assert.deepEqual(result.body, API_6C243_ADVANCED_FINAL_FIXTURE.body);
 });
 
 test('advanced-final reconciliation remains terminal, advancing, and identity exact', async () => {
-  const valid = API_C3_ADVANCED_FINAL_FIXTURE.body;
+  const valid = API_6C243_ADVANCED_FINAL_FIXTURE.body;
   const pendingFinal = mutateReconcile(valid, (body) => {
     body.outcome = 'pending';
     body.mutated = false;
@@ -1239,7 +1239,7 @@ test('advanced-final reconciliation remains terminal, advancing, and identity ex
     apiBase: 'https://api.dexter.test',
     secret: SECRET,
     operation: 'reconcile',
-    input: API_C3_ADVANCED_FINAL_FIXTURE.input,
+    input: API_6C243_ADVANCED_FINAL_FIXTURE.input,
     mcpSessionId: SESSION_ID,
     now: NOW,
     fetchImpl: async () => jsonResponse(200, ownerRefusalTerminal),
@@ -1276,7 +1276,7 @@ test('advanced-final reconciliation remains terminal, advancing, and identity ex
       apiBase: 'https://api.dexter.test',
       secret: SECRET,
       operation: 'reconcile',
-      input: API_C3_ADVANCED_FINAL_FIXTURE.input,
+      input: API_6C243_ADVANCED_FINAL_FIXTURE.input,
       mcpSessionId: SESSION_ID,
       now: NOW,
       fetchImpl: async () => jsonResponse(httpStatus, responseBody),

--- a/tests/open-mcp-manifest.test.mjs
+++ b/tests/open-mcp-manifest.test.mjs
@@ -78,11 +78,11 @@ test('manifest, server identity, and package use one release version', async () 
   assert.equal(packageJson.engines.node, '^20.19.0 || >=22.12.0');
   assert.equal(
     packageJson.dependencies['@dexterai/mcp-instructions'],
-    '2.4.1',
+    '2.4.2-rc.1',
   );
   assert.equal(
     packageJson.dependencies['@dexterai/x402-mcp-tools'],
-    '0.9.0-rc.1',
+    '0.9.0-rc.2',
   );
   assert.equal(
     packageJson.dependencies['@modelcontextprotocol/sdk'],

--- a/tests/open-release-dependencies.test.mjs
+++ b/tests/open-release-dependencies.test.mjs
@@ -364,16 +364,16 @@ test('hosted source declares one exact internal dependency train', async () => {
     manifest.sourcePackages.map(({ name, version }) => `${name}@${version}`),
     [
       '@dexterai/x402-core@1.5.2',
-      '@dexterai/mcp-instructions@2.4.1',
-      '@dexterai/x402-mcp-tools@0.9.0-rc.1',
-      '@dexterai/vault@0.43.2',
+      '@dexterai/mcp-instructions@2.4.2-rc.1',
+      '@dexterai/x402-mcp-tools@0.9.0-rc.2',
+      '@dexterai/vault@0.43.3-rc.1',
     ],
   );
   assert.deepEqual(
     manifest.runtimePackages.map(({ name, version }) =>
       `${name}@${version}`),
     [
-      '@dexterai/x402@6.0.0-rc.3',
+      '@dexterai/x402@6.0.0-rc.4',
       '@modelcontextprotocol/sdk@1.29.0',
       '@modelcontextprotocol/ext-apps@1.6.0',
       'zod@3.25.76',
@@ -397,10 +397,10 @@ test('hosted source declares one exact internal dependency train', async () => {
   );
   assert.deepEqual(manifest.repositories['opendexter-ide'], {
     remote: 'https://github.com/Dexter-DAO/opendexter-ide.git',
-    provenanceCommit: 'd0af97fdff2638042626720e5e69c26d4e7d2ffe',
+    provenanceCommit: '1fe25b170ef17ed15f62ee73cd5128978d8868f9',
     rootWorkspaceBuild: {
       packageLockSha256:
-        '0d59c0ccaa147e852586a4c0e9e15af4aea8de36042b63a0a0371c06c0c39c45',
+        '8bd1f28803e84d2d8e9d0e53c82c2835d337e62a4fada13c49f8a05b63a59a60',
       buildOrder: [
         { workspace: '@dexterai/mcp-instructions', script: 'build' },
         { workspace: '@dexterai/dextercard', script: 'build' },
@@ -411,11 +411,11 @@ test('hosted source declares one exact internal dependency train', async () => {
   for (const [name, tgzSha256] of [
     [
       '@dexterai/mcp-instructions',
-      'c89d5d9bfa5254cbdd641a73c2dc9499446e3c635b024b192ec309a9500d1a3c',
+      'cca551e7302b874479499b57bb2544a4f822e7d5e6a80e1c9d5130c6f45fa2d9',
     ],
     [
       '@dexterai/x402-mcp-tools',
-      '97a132871d8cd1e0e32446ea3b3d7b1afe41a6a0b89fc98d75173f2a48f313a0',
+      '13bfb95fc1eae30588879a0ac173d1e473ac9117d44464116245b8882709d5e9',
     ],
   ]) {
     const artifact = manifest.sourcePackages.find(
@@ -427,28 +427,29 @@ test('hosted source declares one exact internal dependency train', async () => {
   }
   assert.deepEqual(manifest.repositories['vault-sdk'], {
     remote: 'https://github.com/Dexter-DAO/dexter-vault-sdk.git',
-    provenanceCommit: 'd345a9579aef3179ca76026aace9a85d88231484',
+    provenanceCommit: 'cbf56cfb84ec78fe4086cdd665a777f78077efd0',
   });
   assert.deepEqual(
     manifest.sourcePackages.find(({ name }) => name === '@dexterai/vault'),
     {
       name: '@dexterai/vault',
-      version: '0.43.2',
-      rootSpecifier: '0.43.2',
+      version: '0.43.3-rc.1',
+      rootSpecifier: '0.43.3-rc.1',
       source: 'vault-sdk',
       path: '.',
       entrypoint: 'dist/index.js',
-      treeHash: 'b9faf3d3576a988f4786ff5975aa42150c192b55',
+      treeHash: '806e479d12f648e1b69281bec8ed3c01c163a026',
       packedArtifact: {
         buildScript: 'build',
         packLifecycleScripts: {
           prepack: 'npm run build && npm run typecheck',
         },
-        integrity: 'sha512-RYzML634iIEzOCEaBQ5Rur/NsMprZns3+X/1FcrmtOP62aMFnpGKK2Rcp9ncBbvoo1B7wMVLtUvYYkD5w9U/7w==',
-        shasum: '320a24ff9c64f3febc6f7c8f34266c07fd119366',
-        size: 624340,
-        unpackedSize: 3068429,
+        integrity: 'sha512-KBxgQf3pEuz+7fsmyjIlm7xYxa/h1d+2ULoG/EpzTHolxcEuLyPLv4Kz8nbzOTJK8ca7SggHeWIiio/ek3IOiQ==',
+        shasum: '8822a0b9840cf4e29a33daf311824919272c3bdf',
+        size: 624351,
+        unpackedSize: 3068434,
         entryCount: 91,
+        tgzSha256: '1eca5e65d5a2efc2a3fa2bad63b57d1080fa8fd2e33d14a370d7291e749d59d4',
       },
       install: { source: 'registry', release: 'registry' },
     },

--- a/tests/open-release-widget-assets.test.mjs
+++ b/tests/open-release-widget-assets.test.mjs
@@ -38,6 +38,10 @@ async function fixture() {
     '<script type="module" src="./assets/entry-AAAA.js"></script>',
   ].join('\n'));
   await writeFile(join(targetAssets, 'historical-OLD.js'), 'old bytes stay\n');
+  await chmod(targetAssets, 0o700);
+  await chmod(targetRoot, 0o700);
+  await chmod(releaseAssets, 0o500);
+  await chmod(appsRoot, 0o500);
   await chmod(releaseDir, 0o500);
   return {
     root,
@@ -65,6 +69,8 @@ test('sealed release plan binds every HTML reference and all JS/CSS bytes', asyn
     ]);
   } finally {
     await chmod(current.release.releaseDir, 0o700);
+    await chmod(join(current.release.releaseDir, 'public/apps-sdk'), 0o700);
+    await chmod(current.releaseAssets, 0o700);
     await rm(current.root, { recursive: true, force: true });
   }
 });
@@ -93,6 +99,8 @@ test('publish is append-only, atomic by name, and refuses a hash collision', asy
     );
   } finally {
     await chmod(current.release.releaseDir, 0o700);
+    await chmod(join(current.release.releaseDir, 'public/apps-sdk'), 0o700);
+    await chmod(current.releaseAssets, 0o700);
     await rm(current.root, { recursive: true, force: true });
   }
 });
@@ -148,6 +156,8 @@ test('public gate requires 200, exact MIME, and exact sealed bytes', async () =>
     }
   } finally {
     await chmod(current.release.releaseDir, 0o700);
+    await chmod(join(current.release.releaseDir, 'public/apps-sdk'), 0o700);
+    await chmod(current.releaseAssets, 0o700);
     await rm(current.root, { recursive: true, force: true });
   }
 });
@@ -173,6 +183,8 @@ test('public gate also rejects a broken lazy chunk not named by widget HTML', as
     );
   } finally {
     await chmod(current.release.releaseDir, 0o700);
+    await chmod(join(current.release.releaseDir, 'public/apps-sdk'), 0o700);
+    await chmod(current.releaseAssets, 0o700);
     await rm(current.root, { recursive: true, force: true });
   }
 });
@@ -186,10 +198,12 @@ test('plan refuses missing and noncanonical HTML asset references', async () => 
     const current = await fixture();
     try {
       await chmod(current.release.releaseDir, 0o700);
+      await chmod(join(current.release.releaseDir, 'public/apps-sdk'), 0o700);
       await writeFile(join(
         current.release.releaseDir,
         'public/apps-sdk/widget.html',
       ), body);
+      await chmod(join(current.release.releaseDir, 'public/apps-sdk'), 0o500);
       await chmod(current.release.releaseDir, 0o500);
       await assert.rejects(
         readOpenWidgetAssetPlan(current.release),
@@ -197,6 +211,8 @@ test('plan refuses missing and noncanonical HTML asset references', async () => 
       );
     } finally {
       await chmod(current.release.releaseDir, 0o700);
+      await chmod(join(current.release.releaseDir, 'public/apps-sdk'), 0o700);
+      await chmod(current.releaseAssets, 0o700);
       await rm(current.root, { recursive: true, force: true });
     }
   }

--- a/tests/open-source-contracts.test.mjs
+++ b/tests/open-source-contracts.test.mjs
@@ -372,6 +372,7 @@ test('private source receipts bind exact repository refs and descriptor source',
   );
   assert.deepEqual(fixture.receipt.identities[0].refs, [
     'refs/heads/governed-contract',
+    'refs/heads/integrated',
     'refs/tags/governed-contract',
   ]);
 
@@ -812,7 +813,7 @@ test('cross-repository source verifier rejects every identity and byte attack', 
     ['wrong tree', { wrongTree: true }, /commit\/tree identity mismatch/],
     ['non-ancestor release', { nonAncestor: true }, /does not descend/],
     ['governed byte drift', { governedDrift: true }, /changes the frozen/],
-    ['API fixture drift', { fixtureDrift: 'api-integrated' }, /source bytes differ/],
+    ['API fixture drift', { fixtureDrift: 'api-contract' }, /source bytes differ/],
     ['facilitator fixture drift', { fixtureDrift: 'facilitator' }, /source bytes differ/],
     ['portfolio fixture drift', { projectionFixtureDrift: true }, /projection source bytes differ/],
     ['portfolio source missing', {

--- a/tests/open-tool-descriptors.test.mjs
+++ b/tests/open-tool-descriptors.test.mjs
@@ -400,18 +400,18 @@ test('source materializer emits one deterministic full hosted descriptor', async
   ));
   assert.equal(
     descriptor.sourceContracts.api.commit,
-    'c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b',
+    '6c243154e9e06f4e40830300c4027721645a33cc',
   );
   assert.equal(
     descriptor.sourceContracts.api.tree,
-    'b8a3bdd790379f82b959663e679960f213addb5b',
+    'ce2976ada70af9234291aa6a472b3d96a7a84989',
   );
   assert.deepEqual(descriptor.sourceContracts.integratedApiRelease, {
     repository: 'https://github.com/Dexter-DAO/dexter-api',
     commit: acceptedProduction.api.sourceCommit,
     tree: acceptedProduction.api.sourceTree,
-    governedContractCommit: 'c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b',
-    governedContractTree: 'b8a3bdd790379f82b959663e679960f213addb5b',
+    governedContractCommit: '6c243154e9e06f4e40830300c4027721645a33cc',
+    governedContractTree: 'ce2976ada70af9234291aa6a472b3d96a7a84989',
   });
   assert.deepEqual(descriptor.sourceContracts.portfolioProjection, {
     repository: 'https://github.com/Dexter-DAO/dexter-api',


### PR DESCRIPTION
Rebinds the frozen governed API contract and exact reconciliation fixture to the accepted live 6c243 API release, then regenerates the hosted descriptor without changing any other tool bytes.

Preserves the governed-path byte-drift verifier and all hostile identity/fixture/ref checks. Also refreshes exact prerelease dependency witnesses and fixes the widget asset test fixture to model owner-only directories under the host umask.

Verification:
- clean-archive descriptor generation and exact verification
- focused governed/source contract tests: 51 passed
- full hosted suite: 595 passed, 1 intentional skip, 0 failed
- descriptor bytes outside sourceContracts unchanged