### PR TITLE
fix: bridge retired x402 intent calls

### DIFF
--- a/lib/open-legacy-intent-bridge.mjs
+++ b/lib/open-legacy-intent-bridge.mjs
@@ -1,0 +1,288 @@
+import { createHash } from 'node:crypto';
+
+const INTENT_ID_RE = /^.{1,256}$/s;
+const POSITIVE_ATOMIC_RE = /^[1-9]\d{0,19}$/;
+const SURFACE_HASH_RE = /^[0-9a-f]{64}$/;
+const SESSION_ID_RE = /^[A-Za-z0-9_.\-]{1,256}$/;
+const SUPPORTED_METHODS = new Set(['GET', 'POST', 'PUT', 'DELETE']);
+const DEFAULT_TTL_MS = 2 * 60 * 1000;
+const MAX_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_MAX_ENTRIES = 256;
+
+function sha256(parts) {
+  const hash = createHash('sha256');
+  for (const part of parts) {
+    const value = String(part);
+    hash.update(String(Buffer.byteLength(value, 'utf8')));
+    hash.update(':');
+    hash.update(value, 'utf8');
+    hash.update('|');
+  }
+  return hash.digest('hex');
+}
+
+function identityKey(identity) {
+  if (
+    !identity
+    || typeof identity !== 'object'
+    || typeof identity.subject !== 'string'
+    || identity.subject.length < 1
+    || identity.subject.length > 512
+    || typeof identity.surface !== 'string'
+    || !SURFACE_HASH_RE.test(identity.surface)
+    || typeof identity.issuer !== 'string'
+    || identity.issuer.length < 1
+    || identity.issuer.length > 512
+    || typeof identity.audience !== 'string'
+    || identity.audience.length < 1
+    || identity.audience.length > 512
+  ) {
+    return null;
+  }
+  return sha256([
+    identity.subject,
+    identity.surface,
+    identity.issuer,
+    identity.audience,
+  ]);
+}
+
+function exactRequestKey({ url, method = 'GET', body, bodyProvided = false } = {}) {
+  if (typeof url !== 'string' || url.length < 1 || url.length > 16_384) return null;
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:' || parsed.username || parsed.password || parsed.hash) {
+    return null;
+  }
+  const canonicalMethod = String(method || 'GET').toUpperCase();
+  if (!SUPPORTED_METHODS.has(canonicalMethod)) return null;
+  if (bodyProvided && typeof body !== 'string') return null;
+  if (canonicalMethod === 'GET' && bodyProvided) return null;
+  return sha256([
+    url,
+    canonicalMethod,
+    bodyProvided ? 'body' : 'absent',
+    bodyProvided ? body : '',
+  ]);
+}
+
+function exactAmount(paymentOptions) {
+  if (!Array.isArray(paymentOptions) || paymentOptions.length < 1) return null;
+  const values = paymentOptions.map((option) => option?.amountAtomic);
+  if (values.some((value) => typeof value !== 'string' || !POSITIVE_ATOMIC_RE.test(value))) {
+    return null;
+  }
+  const amounts = new Set(values);
+  return amounts.size === 1 ? [...amounts][0] : null;
+}
+
+function boundedExpiry(paymentOptions, now) {
+  const sellerExpiries = Array.isArray(paymentOptions)
+    ? paymentOptions
+        .map((option) => Date.parse(option?.expiresAt))
+        .filter((value) => Number.isFinite(value) && value > now)
+    : [];
+  const sellerExpiry = sellerExpiries.length > 0
+    ? Math.min(...sellerExpiries)
+    : now + DEFAULT_TTL_MS;
+  return Math.min(sellerExpiry, now + MAX_TTL_MS);
+}
+
+function legacyFetchCall(message) {
+  if (
+    !message
+    || typeof message !== 'object'
+    || Array.isArray(message)
+    || message.method !== 'tools/call'
+    || message.params?.name !== 'x402_fetch'
+  ) {
+    return null;
+  }
+  const args = message.params.arguments;
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return null;
+  if (Object.prototype.hasOwnProperty.call(args, 'intentId')) return null;
+  const allowed = new Set(['url', 'method', 'body', 'maxAmountAtomic']);
+  if (Object.keys(args).some((key) => !allowed.has(key))) return null;
+  return { message, args };
+}
+
+function legacyCalls(body) {
+  const messages = Array.isArray(body) ? body : [body];
+  return messages.map(legacyFetchCall).filter(Boolean);
+}
+
+function replaceLegacyCall(body, target, intentId) {
+  const replace = (message) => message === target
+    ? {
+        ...message,
+        params: {
+          ...message.params,
+          arguments: {
+            intentId,
+            maxAmountAtomic: message.params.arguments.maxAmountAtomic,
+          },
+        },
+      }
+    : message;
+  return Array.isArray(body) ? body.map(replace) : replace(body);
+}
+
+export function createLegacyIntentBridge({
+  now = Date.now,
+  maxEntries = DEFAULT_MAX_ENTRIES,
+} = {}) {
+  if (typeof now !== 'function') throw new TypeError('legacy_intent_bridge_now_required');
+  if (!Number.isSafeInteger(maxEntries) || maxEntries < 1 || maxEntries > 4096) {
+    throw new TypeError('invalid_legacy_intent_bridge_capacity');
+  }
+  const records = new Map();
+
+  function purge(currentTime) {
+    for (const [key, record] of records) {
+      if (record.expiresAt <= currentTime) records.delete(key);
+    }
+  }
+
+  function recordCheck({ identity, sessionId, modelResult } = {}) {
+    const currentTime = now();
+    purge(currentTime);
+    const boundIdentity = identityKey(identity);
+    const checkedRequest = modelResult?.checkedRequest;
+    const request = exactRequestKey({
+      url: checkedRequest?.url,
+      method: checkedRequest?.method,
+      body: checkedRequest?.body,
+      bodyProvided: checkedRequest?.body !== null,
+    });
+    const intentId = modelResult?.intentId;
+    const amountAtomic = exactAmount(modelResult?.paymentOptions);
+    if (
+      !boundIdentity
+      || typeof sessionId !== 'string'
+      || !SESSION_ID_RE.test(sessionId)
+      || !request
+      || typeof intentId !== 'string'
+      || !INTENT_ID_RE.test(intentId)
+      || intentId !== intentId.trim()
+      || !amountAtomic
+      || modelResult?.quoteOnly !== false
+      || checkedRequest?.requestBound !== true
+      || modelResult?.executionGuidance?.readyForFetch !== true
+      || modelResult?.executionGuidance?.supportedPath !== 'fetch_by_intent'
+    ) {
+      return false;
+    }
+    const key = `${boundIdentity}:${request}`;
+    const expiresAt = boundedExpiry(modelResult.paymentOptions, currentTime);
+    const existing = records.get(key);
+    if (existing && existing.intentId !== intentId) {
+      records.set(key, {
+        ...existing,
+        state: 'ambiguous',
+        expiresAt: Math.max(existing.expiresAt, expiresAt),
+      });
+      return false;
+    }
+    if (!existing && records.size >= maxEntries) return false;
+    records.set(key, {
+      intentId,
+      identityKey: boundIdentity,
+      checkedSessionId: existing?.checkedSessionId ?? sessionId,
+      amountAtomic,
+      expiresAt,
+      state: existing?.state ?? 'active',
+      claimedBySessionId: existing?.claimedBySessionId ?? null,
+    });
+    return true;
+  }
+
+  function rewrite(body, { identity, sessionId } = {}) {
+    const currentTime = now();
+    purge(currentTime);
+    // This compatibility path is deliberately single-dispatch only. A JSON-RPC
+    // batch could hide another canonical or malformed spend call beside the
+    // retired one, so leave every batch untouched for normal SDK rejection.
+    if (Array.isArray(body)) return { body, rewritten: false };
+    const calls = legacyCalls(body);
+    if (calls.length !== 1) return { body, rewritten: false };
+    if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) {
+      return { body, rewritten: false };
+    }
+    const boundIdentity = identityKey(identity);
+    if (!boundIdentity) return { body, rewritten: false };
+    const [{ message, args }] = calls;
+    if (
+      typeof args.maxAmountAtomic !== 'string'
+      || !POSITIVE_ATOMIC_RE.test(args.maxAmountAtomic)
+    ) {
+      return { body, rewritten: false };
+    }
+    const bodyProvided = Object.prototype.hasOwnProperty.call(args, 'body');
+    const request = exactRequestKey({
+      url: args.url,
+      method: args.method || 'GET',
+      body: args.body,
+      bodyProvided,
+    });
+    if (!request) return { body, rewritten: false };
+    const record = records.get(`${boundIdentity}:${request}`);
+    if (
+      !record
+      || record.state !== 'active'
+      || record.amountAtomic !== args.maxAmountAtomic
+      || record.expiresAt <= currentTime
+    ) {
+      return { body, rewritten: false };
+    }
+    record.state = 'claimed';
+    record.claimedBySessionId = sessionId;
+    return {
+      body: replaceLegacyCall(body, message, record.intentId),
+      rewritten: true,
+      intentId: record.intentId,
+    };
+  }
+
+  function complete({ identity, intentId, sessionId, result } = {}) {
+    const boundIdentity = identityKey(identity);
+    let matched = false;
+    for (const record of records.values()) {
+      if (
+        record.state === 'claimed'
+        && record.identityKey === boundIdentity
+        && record.intentId === intentId
+        && record.claimedBySessionId === sessionId
+      ) {
+        matched = true;
+        const knownPreDispatchAuthorization =
+          result?.status === 'authorization_required'
+          && result?.authorizationRequired === true
+          && result?.retryWithSameIntentOnly === true;
+        record.state = knownPreDispatchAuthorization ? 'active' : 'consumed';
+        record.claimedBySessionId = null;
+      }
+    }
+    return matched;
+  }
+
+  function checkedSessionId({ identity, intentId, sessionId } = {}) {
+    const boundIdentity = identityKey(identity);
+    for (const record of records.values()) {
+      if (
+        record.state === 'claimed'
+        && record.identityKey === boundIdentity
+        && record.intentId === intentId
+        && record.claimedBySessionId === sessionId
+      ) {
+        return record.checkedSessionId;
+      }
+    }
+    return null;
+  }
+
+  return Object.freeze({ recordCheck, rewrite, checkedSessionId, complete });
+}

--- a/open-mcp-server.mjs
+++ b/open-mcp-server.mjs
@@ -85,6 +85,7 @@ import {
   buildAnonVaultToolResult,
   normalizeAnonVaultFetchResponse,
 } from './lib/anon-vault-response.mjs';
+import { createLegacyIntentBridge } from './lib/open-legacy-intent-bridge.mjs';
 import {
   DEFAULT_MULTIPART_MAX_BYTES,
   loadSafeUploadFiles,
@@ -135,6 +136,7 @@ import {
   isVaultBound,
   markAccountBound,
   markVaultBound,
+  oauthVaultIdentityOf,
   oauthVaultIdentityStatus,
   pinOAuthVaultIdentity,
   touchOpenSessionMeta,
@@ -172,6 +174,7 @@ const LOG_CORRELATION_KEY =
 const logRef = createLogRef(LOG_CORRELATION_KEY);
 const WEBAUTHN_PROBE_TELEMETRY_ENABLED =
   isWebauthnProbeTelemetryEnabled(process.env);
+const legacyIntentBridge = createLegacyIntentBridge();
 /**
  * Capability search endpoint — semantic vector search over the x402 corpus
  * with synonym expansion, similarity floor, strong/related tiering, and
@@ -671,7 +674,11 @@ function intentConsentResult({ intentId, maxAmountAtomic, data }) {
   });
 }
 
-async function x402IntentFetch({ intentId, maxAmountAtomic }, extra) {
+async function x402IntentFetch(
+  { intentId, maxAmountAtomic },
+  extra,
+  { checkedSessionId = null } = {},
+) {
   const session = await resolveIntentSession(extra);
   if (!session.sessionId || !session.authenticated) {
     if (session.lookupFailed) {
@@ -696,7 +703,7 @@ async function x402IntentFetch({ intentId, maxAmountAtomic }, extra) {
     });
   }
   const response = await callOpenX402IntentApi('fetch', {
-    sessionId: session.sessionId,
+    sessionId: checkedSessionId || session.sessionId,
     intentId,
     maxAmountAtomic,
   });
@@ -2048,8 +2055,21 @@ export function createOpenMcpServer({
     annotations: { destructiveHint: true },
     _meta: FETCH_META,
   }, async (args, extra) => {
+    const sessionId = extra ? extractMcpSessionId(extra) : null;
+    const identity = oauthVaultIdentityOf(sessionMeta.get(sessionId));
     try {
-      const result = await x402IntentFetch(args, extra);
+      const checkedSessionId = legacyIntentBridge.checkedSessionId({
+        identity,
+        intentId: args.intentId,
+        sessionId,
+      });
+      const result = await x402IntentFetch(args, extra, { checkedSessionId });
+      legacyIntentBridge.complete({
+        identity,
+        intentId: args.intentId,
+        sessionId,
+        result,
+      });
       const meta = { ...FETCH_META };
       if (isVaultAuthenticationRequired(result)) {
         return vaultAuthenticationResult(result, meta);
@@ -2061,6 +2081,14 @@ export function createOpenMcpServer({
         _meta: meta,
       };
     } catch (err) {
+      // A transport/API exception after the compatibility claim is uncertain.
+      // Keep that record consumed so a stale client cannot auto-dispatch twice.
+      legacyIntentBridge.complete({
+        identity,
+        intentId: args.intentId,
+        sessionId,
+        result: null,
+      });
       console.warn(
         `[x402_fetch] intent API failed (${safeErrorLabel(err)}) `
         + `intentRef=${logRef(args.intentId)}`,
@@ -2220,6 +2248,13 @@ export function createOpenMcpServer({
         enrichment,
         enrichmentSource,
       });
+      if (session.authenticated && session.sessionId) {
+        legacyIntentBridge.recordCheck({
+          identity: oauthVaultIdentityOf(sessionMeta.get(session.sessionId)),
+          sessionId: session.sessionId,
+          modelResult,
+        });
+      }
       // Keep the text content LEAN — the widget reads structuredContent, the
       // LLM reads text. Dumping the full enriched payload (with embedded
       // response_preview JSON-in-JSON strings) into text was tripping the
@@ -3152,6 +3187,18 @@ const httpServer = http.createServer(async (req, res) => {
           writeVaultChallenge(res);
           return; // session state untouched — the client retries on the same id
         }
+      }
+
+      const bridged = legacyIntentBridge.rewrite(parsedBody, {
+        identity: oauthVaultIdentityOf(sessionMeta.get(sessionId)),
+        sessionId,
+      });
+      if (bridged.rewritten) {
+        parsedBody = bridged.body;
+        console.log(
+          `[open-mcp] translated retired x402_fetch schema `
+          + `sessionRef=${logRef(sessionId)} intentRef=${logRef(bridged.intentId)}`,
+        );
       }
 
       const transport = transports.get(sessionId);

--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -16,15 +16,15 @@
     },
     "integratedApiRelease": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "6c243154e9e06f4e40830300c4027721645a33cc",
-      "tree": "ce2976ada70af9234291aa6a472b3d96a7a84989",
+      "commit": "42c2a81bc35835e50d4c18179c47494a58e1bfb6",
+      "tree": "ddaabed6b70e4af9d204db0623ed677285a91015",
       "governedContractCommit": "6c243154e9e06f4e40830300c4027721645a33cc",
       "governedContractTree": "ce2976ada70af9234291aa6a472b3d96a7a84989"
     },
     "portfolioProjection": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "6c243154e9e06f4e40830300c4027721645a33cc",
-      "tree": "ce2976ada70af9234291aa6a472b3d96a7a84989",
+      "commit": "42c2a81bc35835e50d4c18179c47494a58e1bfb6",
+      "tree": "ddaabed6b70e4af9d204db0623ed677285a91015",
       "sourcePaths": [
         "src/portfolio/approvedActionTargets.ts",
         "src/routes/passkeyMcpBinding.ts",

--- a/release/opendexter-accepted-production.json
+++ b/release/opendexter-accepted-production.json
@@ -4,12 +4,12 @@
   "api": {
     "endpoint": "https://api.dexter.cash/health",
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "releaseId": "6c243154e9e0-898d1625fede3382-4db7cccbd774",
-    "sourceCommit": "6c243154e9e06f4e40830300c4027721645a33cc",
-    "sourceTree": "ce2976ada70af9234291aa6a472b3d96a7a84989",
-    "toolingCommit": "6c243154e9e06f4e40830300c4027721645a33cc",
-    "artifactSha256": "898d1625fede3382b934c860ab514b863818b829f632ba6c4a51580fe64cbaf6",
-    "metadataBindingSha256": "3453b5479ea09f8b5da12de7be526c0efe99cdc20be1c3e8e04501312f3fb1c8"
+    "releaseId": "42c2a81bc358-73a292c396a7c51d-4db7cccbd774",
+    "sourceCommit": "42c2a81bc35835e50d4c18179c47494a58e1bfb6",
+    "sourceTree": "ddaabed6b70e4af9d204db0623ed677285a91015",
+    "toolingCommit": "42c2a81bc35835e50d4c18179c47494a58e1bfb6",
+    "artifactSha256": "73a292c396a7c51de55e0b53f63ace8f4c9b795dee6bd950096ab0bd86563ba5",
+    "metadataBindingSha256": "4525234092fd3d0a1ec620fac79665f2b23e39242ebf9b04c3405564593b1f2c"
   },
   "facilitator": {
     "endpoint": "https://x402.dexter.cash/version",

--- a/release/opendexter-source-contracts.json
+++ b/release/opendexter-source-contracts.json
@@ -13,15 +13,15 @@
   },
   "integratedApiRelease": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "6c243154e9e06f4e40830300c4027721645a33cc",
-    "tree": "ce2976ada70af9234291aa6a472b3d96a7a84989",
+    "commit": "42c2a81bc35835e50d4c18179c47494a58e1bfb6",
+    "tree": "ddaabed6b70e4af9d204db0623ed677285a91015",
     "governedContractCommit": "6c243154e9e06f4e40830300c4027721645a33cc",
     "governedContractTree": "ce2976ada70af9234291aa6a472b3d96a7a84989"
   },
   "portfolioProjection": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "6c243154e9e06f4e40830300c4027721645a33cc",
-    "tree": "ce2976ada70af9234291aa6a472b3d96a7a84989",
+    "commit": "42c2a81bc35835e50d4c18179c47494a58e1bfb6",
+    "tree": "ddaabed6b70e4af9d204db0623ed677285a91015",
     "sourcePaths": [
       "src/portfolio/approvedActionTargets.ts",
       "src/routes/passkeyMcpBinding.ts",

--- a/tests/open-legacy-intent-bridge.test.mjs
+++ b/tests/open-legacy-intent-bridge.test.mjs
@@ -1,0 +1,235 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createLegacyIntentBridge } from '../lib/open-legacy-intent-bridge.mjs';
+
+const IDENTITY = Object.freeze({
+  subject: 'user-1',
+  surface: 'a'.repeat(64),
+  issuer: 'https://dexter.cash',
+  audience: 'https://open.dexter.cash/mcp',
+});
+const OTHER_IDENTITY = Object.freeze({
+  ...IDENTITY,
+  surface: 'b'.repeat(64),
+});
+const URL = 'https://api.example.test/paid?q=exact';
+const CHECK_SESSION = 'checked-mcp-session';
+
+function checked({
+  intentId = 'intent-1',
+  url = URL,
+  method = 'GET',
+  body = null,
+  amountAtomic = '50000',
+  expiresAt = '2026-08-17T17:02:00.000Z',
+} = {}) {
+  return {
+    intentId,
+    quoteOnly: false,
+    paymentOptions: [{ amountAtomic, expiresAt }],
+    checkedRequest: {
+      url,
+      method,
+      body,
+      requestBound: true,
+    },
+    executionGuidance: {
+      supportedPath: 'fetch_by_intent',
+      readyForFetch: true,
+    },
+  };
+}
+
+function call(args, id = 1) {
+  return {
+    jsonrpc: '2.0',
+    id,
+    method: 'tools/call',
+    params: { name: 'x402_fetch', arguments: args },
+  };
+}
+
+test('same OAuth surface rewrites one exact stale fetch to the opaque intent', () => {
+  let clock = Date.parse('2026-08-17T17:00:00.000Z');
+  const bridge = createLegacyIntentBridge({ now: () => clock });
+  assert.equal(bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() }), true);
+
+  const original = call({ url: URL, method: 'GET', maxAmountAtomic: '50000' });
+  const translated = bridge.rewrite(original, {
+    identity: { ...IDENTITY },
+    sessionId: 'new-mcp-session',
+  });
+  assert.equal(translated.rewritten, true);
+  assert.deepEqual(translated.body.params.arguments, {
+    intentId: 'intent-1',
+    maxAmountAtomic: '50000',
+  });
+  assert.equal(bridge.checkedSessionId({
+    identity: IDENTITY,
+    intentId: 'intent-1',
+    sessionId: 'new-mcp-session',
+  }), CHECK_SESSION);
+  assert.equal(bridge.checkedSessionId({
+    identity: OTHER_IDENTITY,
+    intentId: 'intent-1',
+    sessionId: 'new-mcp-session',
+  }), null);
+  assert.deepEqual(original.params.arguments, {
+    url: URL,
+    method: 'GET',
+    maxAmountAtomic: '50000',
+  });
+
+  // Once claimed, a concurrent/repeated stale call cannot dispatch again.
+  assert.equal(bridge.rewrite(original, {
+    identity: IDENTITY,
+    sessionId: 'new-mcp-session',
+  }).rewritten, false);
+  clock += 1;
+});
+
+test('known pre-dispatch authorization releases only the same claimed intent', () => {
+  const bridge = createLegacyIntentBridge({
+    now: () => Date.parse('2026-08-17T17:00:00.000Z'),
+  });
+  bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
+  const original = call({ url: URL, maxAmountAtomic: '50000' });
+  const first = bridge.rewrite(original, {
+    identity: IDENTITY,
+    sessionId: 'session-a',
+  });
+  assert.equal(first.rewritten, true);
+  assert.equal(bridge.complete({
+    identity: IDENTITY,
+    intentId: 'intent-1',
+    sessionId: 'session-a',
+    result: {
+      status: 'authorization_required',
+      authorizationRequired: true,
+      retryWithSameIntentOnly: true,
+    },
+  }), true);
+  assert.equal(bridge.rewrite(original, {
+    identity: IDENTITY,
+    sessionId: 'session-b',
+  }).rewritten, true);
+});
+
+test('success, error, or uncertainty consumes the bridge record', () => {
+  for (const result of [
+    { status: 'complete', ok: true },
+    { status: 'authorization_required', authorizationRequired: true },
+    null,
+  ]) {
+    const bridge = createLegacyIntentBridge({
+      now: () => Date.parse('2026-08-17T17:00:00.000Z'),
+    });
+    bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
+    const original = call({ url: URL, maxAmountAtomic: '50000' });
+    assert.equal(bridge.rewrite(original, {
+      identity: IDENTITY,
+      sessionId: 'session-a',
+    }).rewritten, true);
+    bridge.complete({ identity: IDENTITY, intentId: 'intent-1', sessionId: 'session-a', result });
+    assert.equal(bridge.rewrite(original, {
+      identity: IDENTITY,
+      sessionId: 'session-b',
+    }).rewritten, false);
+  }
+});
+
+test('identity, exact request bytes, and quoted amount are all hard bindings', () => {
+  const bridge = createLegacyIntentBridge({
+    now: () => Date.parse('2026-08-17T17:00:00.000Z'),
+  });
+  bridge.recordCheck({
+    identity: IDENTITY,
+    sessionId: CHECK_SESSION,
+    modelResult: checked({ method: 'POST', body: '{"q":"exact"}' }),
+  });
+  const variants = [
+    [OTHER_IDENTITY, { url: URL, method: 'POST', body: '{"q":"exact"}', maxAmountAtomic: '50000' }],
+    [IDENTITY, { url: `${URL}&extra=1`, method: 'POST', body: '{"q":"exact"}', maxAmountAtomic: '50000' }],
+    [IDENTITY, { url: URL, method: 'PUT', body: '{"q":"exact"}', maxAmountAtomic: '50000' }],
+    [IDENTITY, { url: URL, method: 'POST', body: '{"q": "exact"}', maxAmountAtomic: '50000' }],
+    [IDENTITY, { url: URL, method: 'POST', body: '{"q":"exact"}', maxAmountAtomic: '50001' }],
+    [IDENTITY, { url: URL, method: 'POST', body: '{"q":"exact"}', maxAmountAtomic: '50000', purchase: {} }],
+  ];
+  for (const [identity, args] of variants) {
+    assert.equal(bridge.rewrite(call(args), {
+      identity,
+      sessionId: 'session-a',
+    }).rewritten, false);
+  }
+  assert.equal(bridge.rewrite(call({
+    url: URL,
+    method: 'POST',
+    body: '{"q":"exact"}',
+    maxAmountAtomic: '50000',
+  }), {
+    identity: IDENTITY,
+    sessionId: 'session-a',
+  }).rewritten, true);
+});
+
+test('ambiguous, expired, quote-only, or multi-call inputs fail closed', () => {
+  let clock = Date.parse('2026-08-17T17:00:00.000Z');
+  const bridge = createLegacyIntentBridge({ now: () => clock });
+  assert.equal(bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() }), true);
+  assert.equal(bridge.recordCheck({
+    identity: IDENTITY,
+    sessionId: CHECK_SESSION,
+    modelResult: checked({ intentId: 'intent-2' }),
+  }), false);
+  const stale = call({ url: URL, maxAmountAtomic: '50000' });
+  assert.equal(bridge.rewrite(stale, {
+    identity: IDENTITY,
+    sessionId: 'session-a',
+  }).rewritten, false);
+
+  const expired = createLegacyIntentBridge({ now: () => clock });
+  expired.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
+  clock = Date.parse('2026-08-17T17:02:00.001Z');
+  assert.equal(expired.rewrite(stale, {
+    identity: IDENTITY,
+    sessionId: 'session-a',
+  }).rewritten, false);
+
+  const quoteOnly = checked();
+  quoteOnly.quoteOnly = true;
+  assert.equal(expired.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: quoteOnly }), false);
+
+  const batch = createLegacyIntentBridge({
+    now: () => Date.parse('2026-08-17T17:00:00.000Z'),
+  });
+  batch.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
+  const body = [stale, call({ url: URL, maxAmountAtomic: '50000' }, 2)];
+  assert.equal(batch.rewrite(body, {
+    identity: IDENTITY,
+    sessionId: 'session-a',
+  }).rewritten, false);
+
+  const invalidSession = createLegacyIntentBridge({ now: () => clock });
+  assert.equal(invalidSession.recordCheck({
+    identity: IDENTITY,
+    sessionId: 'session with spaces',
+    modelResult: checked(),
+  }), false);
+});
+
+test('canonical intent calls are never rewritten or claimed', () => {
+  const bridge = createLegacyIntentBridge({
+    now: () => Date.parse('2026-08-17T17:00:00.000Z'),
+  });
+  bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
+  const canonical = call({ intentId: 'intent-1', maxAmountAtomic: '50000' });
+  assert.deepEqual(bridge.rewrite(canonical, {
+    identity: IDENTITY,
+    sessionId: 'session-a',
+  }), { body: canonical, rewritten: false });
+  assert.equal(bridge.rewrite(call({ url: URL, maxAmountAtomic: '50000' }), {
+    identity: IDENTITY,
+    sessionId: 'session-a',
+  }).rewritten, true);
+});

--- a/tests/x402-money-boundary.test.mjs
+++ b/tests/x402-money-boundary.test.mjs
@@ -33,7 +33,8 @@ test('public fetch accepts exactly opaque intent and approved ceiling', () => {
     schema,
     /\b(?:url|method|body|multipart|tab|purchase|route|payTo|asset|network|challenge):/,
   );
-  assert.match(source, /x402IntentFetch\(args, extra\)/);
+  assert.match(source, /x402IntentFetch\(args, extra, \{ checkedSessionId \}\)/);
+  assert.match(source, /legacyIntentBridge\.checkedSessionId/);
   assert.doesNotMatch(source, /x402Fetch\(args, extra\)/);
 });
 
@@ -80,4 +81,25 @@ test('intent handlers never expose caller-carried route or prepared JSON', () =>
   );
   assert.match(fetchAndStatus, /sanitizeOpenX402IntentResult/);
   assert.match(fetchAndStatus, /retryWithSameIntentOnly/);
+});
+
+test('retired fetch compatibility runs only after OAuth proof and preserves the checked session', () => {
+  const rawStart = serverSource.indexOf('const protectedCall = findVaultProtectedToolCall');
+  const verified = serverSource.indexOf('if (verification.ok)', rawStart);
+  const rewrite = serverSource.indexOf('legacyIntentBridge.rewrite(parsedBody', rawStart);
+  const dispatch = serverSource.indexOf('transport.handleRequest(req, res, parsedBody)', rewrite);
+  assert.ok(rawStart >= 0 && verified > rawStart, 'OAuth boundary missing');
+  assert.ok(rewrite > verified, 'legacy rewrite must follow current Bearer verification');
+  assert.ok(dispatch > rewrite, 'legacy rewrite must precede SDK input validation/dispatch');
+
+  const source = registration('x402_fetch', 'x402_status');
+  assert.match(source, /oauthVaultIdentityOf\(sessionMeta\.get\(sessionId\)\)/);
+  assert.match(source, /legacyIntentBridge\.checkedSessionId\(\{\s*identity,/);
+  assert.match(source, /x402IntentFetch\(args, extra, \{ checkedSessionId \}\)/);
+
+  const fetchFunction = serverSource.slice(
+    serverSource.indexOf('async function x402IntentFetch'),
+    serverSource.indexOf('async function x402IntentStatus'),
+  );
+  assert.match(fetchFunction, /sessionId: checkedSessionId \|\| session\.sessionId/);
 });


### PR DESCRIPTION
Fail-closed compatibility for authenticated retired app clients. Public schema remains opaque intentId plus ceiling. Exact OAuth identity/request/amount/expiry and original checked MCP session are server-bound; batches, ambiguity, mismatches, and uncertain retries refuse. Focused suites green; full suite 600 pass/1 skip with two unrelated loaded activation timing assertions immediately green in isolation.