### PR TITLE
fix: preserve checked x402 intent session

### DIFF
--- a/lib/open-legacy-intent-bridge.mjs
+++ b/lib/open-legacy-intent-bridge.mjs
@@ -115,6 +115,30 @@ function legacyCalls(body) {
   return messages.map(legacyFetchCall).filter(Boolean);
 }
 
+function canonicalFetchCall(message) {
+  if (
+    !message
+    || typeof message !== 'object'
+    || Array.isArray(message)
+    || message.method !== 'tools/call'
+    || message.params?.name !== 'x402_fetch'
+  ) {
+    return null;
+  }
+  const args = message.params.arguments;
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return null;
+  const allowed = new Set(['intentId', 'maxAmountAtomic']);
+  if (
+    Object.keys(args).some((key) => !allowed.has(key))
+    || typeof args.intentId !== 'string'
+    || !INTENT_ID_RE.test(args.intentId)
+    || args.intentId !== args.intentId.trim()
+  ) {
+    return null;
+  }
+  return { message, args };
+}
+
 function replaceLegacyCall(body, target, intentId) {
   const replace = (message) => message === target
     ? {
@@ -140,10 +164,14 @@ export function createLegacyIntentBridge({
     throw new TypeError('invalid_legacy_intent_bridge_capacity');
   }
   const records = new Map();
+  const intentRecords = new Map();
 
   function purge(currentTime) {
     for (const [key, record] of records) {
       if (record.expiresAt <= currentTime) records.delete(key);
+    }
+    for (const [key, record] of intentRecords) {
+      if (record.expiresAt <= currentTime) intentRecords.delete(key);
     }
   }
 
@@ -177,72 +205,129 @@ export function createLegacyIntentBridge({
       return false;
     }
     const key = `${boundIdentity}:${request}`;
+    const intentKey = `${boundIdentity}:${intentId}`;
     const expiresAt = boundedExpiry(modelResult.paymentOptions, currentTime);
+    const existingIntent = intentRecords.get(intentKey);
+    if (!existingIntent && intentRecords.size >= maxEntries) return false;
+    const intentRecord = existingIntent ?? {
+      intentId,
+      identityKey: boundIdentity,
+      checkedSessionId: sessionId,
+      amountAtomic,
+      expiresAt,
+      state: 'active',
+      reservedBySessionId: null,
+      claimedBySessionId: null,
+    };
+    intentRecord.expiresAt = Math.max(intentRecord.expiresAt, expiresAt);
+    intentRecords.set(intentKey, intentRecord);
     const existing = records.get(key);
     if (existing && existing.intentId !== intentId) {
-      records.set(key, {
-        ...existing,
-        state: 'ambiguous',
-        expiresAt: Math.max(existing.expiresAt, expiresAt),
-      });
+      existing.state = 'ambiguous';
+      existing.reservedBySessionId = null;
+      existing.expiresAt = Math.max(existing.expiresAt, expiresAt);
       return false;
     }
     if (!existing && records.size >= maxEntries) return false;
-    records.set(key, {
-      intentId,
-      identityKey: boundIdentity,
-      checkedSessionId: existing?.checkedSessionId ?? sessionId,
-      amountAtomic,
-      expiresAt,
-      state: existing?.state ?? 'active',
-      claimedBySessionId: existing?.claimedBySessionId ?? null,
-    });
+    records.set(key, intentRecord);
     return true;
   }
 
-  function rewrite(body, { identity, sessionId } = {}) {
+  function beginFetch({ identity, intentId, maxAmountAtomic, sessionId } = {}) {
     const currentTime = now();
     purge(currentTime);
-    // This compatibility path is deliberately single-dispatch only. A JSON-RPC
-    // batch could hide another canonical or malformed spend call beside the
-    // retired one, so leave every batch untouched for normal SDK rejection.
-    if (Array.isArray(body)) return { body, rewritten: false };
-    const calls = legacyCalls(body);
-    if (calls.length !== 1) return { body, rewritten: false };
+    const boundIdentity = identityKey(identity);
+    if (
+      !boundIdentity
+      || typeof intentId !== 'string'
+      || !INTENT_ID_RE.test(intentId)
+      || intentId !== intentId.trim()
+      || typeof maxAmountAtomic !== 'string'
+      || !POSITIVE_ATOMIC_RE.test(maxAmountAtomic)
+      || typeof sessionId !== 'string'
+      || !SESSION_ID_RE.test(sessionId)
+    ) {
+      return Object.freeze({ matched: false, acquired: false, checkedSessionId: null });
+    }
+    const record = intentRecords.get(`${boundIdentity}:${intentId}`);
+    if (!record) {
+      return Object.freeze({ matched: false, acquired: false, checkedSessionId: null });
+    }
+    if (
+      record.state !== 'reserved'
+      || record.reservedBySessionId !== sessionId
+      || record.amountAtomic !== maxAmountAtomic
+    ) {
+      return Object.freeze({ matched: true, acquired: false, checkedSessionId: null });
+    }
+    record.state = 'claimed';
+    record.reservedBySessionId = null;
+    record.claimedBySessionId = sessionId;
+    return Object.freeze({
+      matched: true,
+      acquired: true,
+      checkedSessionId: record.checkedSessionId,
+    });
+  }
+
+  function reserve(body, { identity, sessionId } = {}) {
+    const currentTime = now();
+    purge(currentTime);
+    const untouched = { body, matched: false, reserved: false, rewritten: false };
+    // A JSON-RPC batch can hide another spend call. Never reserve any fetch in
+    // a batch, even when one member happens to be valid.
+    if (Array.isArray(body)) return untouched;
     if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) {
-      return { body, rewritten: false };
+      return untouched;
     }
     const boundIdentity = identityKey(identity);
-    if (!boundIdentity) return { body, rewritten: false };
-    const [{ message, args }] = calls;
+    if (!boundIdentity) return untouched;
+    const canonical = canonicalFetchCall(body);
+    const legacy = legacyCalls(body)[0] ?? null;
+    const selected = canonical || legacy;
+    if (!selected) return untouched;
+    const { message, args } = selected;
     if (
       typeof args.maxAmountAtomic !== 'string'
       || !POSITIVE_ATOMIC_RE.test(args.maxAmountAtomic)
     ) {
-      return { body, rewritten: false };
+      return untouched;
     }
-    const bodyProvided = Object.prototype.hasOwnProperty.call(args, 'body');
-    const request = exactRequestKey({
-      url: args.url,
-      method: args.method || 'GET',
-      body: args.body,
-      bodyProvided,
-    });
-    if (!request) return { body, rewritten: false };
-    const record = records.get(`${boundIdentity}:${request}`);
+    let record;
+    if (canonical) {
+      record = intentRecords.get(`${boundIdentity}:${args.intentId}`);
+    } else {
+      const bodyProvided = Object.prototype.hasOwnProperty.call(args, 'body');
+      const request = exactRequestKey({
+        url: args.url,
+        method: args.method || 'GET',
+        body: args.body,
+        bodyProvided,
+      });
+      if (!request) return untouched;
+      record = records.get(`${boundIdentity}:${request}`);
+    }
+    if (!record) return untouched;
     if (
-      !record
-      || record.state !== 'active'
+      record.state !== 'active'
       || record.amountAtomic !== args.maxAmountAtomic
       || record.expiresAt <= currentTime
     ) {
-      return { body, rewritten: false };
+      return {
+        body,
+        matched: true,
+        reserved: false,
+        rewritten: false,
+        intentId: record.intentId,
+      };
     }
-    record.state = 'claimed';
-    record.claimedBySessionId = sessionId;
+    record.state = 'reserved';
+    record.reservedBySessionId = sessionId;
     return {
-      body: replaceLegacyCall(body, message, record.intentId),
-      rewritten: true,
+      body: legacy ? replaceLegacyCall(body, message, record.intentId) : body,
+      matched: true,
+      reserved: true,
+      rewritten: Boolean(legacy),
       intentId: record.intentId,
     };
   }
@@ -250,7 +335,7 @@ export function createLegacyIntentBridge({
   function complete({ identity, intentId, sessionId, result } = {}) {
     const boundIdentity = identityKey(identity);
     let matched = false;
-    for (const record of records.values()) {
+    for (const record of [...records.values(), ...intentRecords.values()]) {
       if (
         record.state === 'claimed'
         && record.identityKey === boundIdentity
@@ -263,26 +348,17 @@ export function createLegacyIntentBridge({
           && result?.authorizationRequired === true
           && result?.retryWithSameIntentOnly === true;
         record.state = knownPreDispatchAuthorization ? 'active' : 'consumed';
+        record.reservedBySessionId = null;
         record.claimedBySessionId = null;
       }
     }
     return matched;
   }
 
-  function checkedSessionId({ identity, intentId, sessionId } = {}) {
-    const boundIdentity = identityKey(identity);
-    for (const record of records.values()) {
-      if (
-        record.state === 'claimed'
-        && record.identityKey === boundIdentity
-        && record.intentId === intentId
-        && record.claimedBySessionId === sessionId
-      ) {
-        return record.checkedSessionId;
-      }
-    }
-    return null;
-  }
-
-  return Object.freeze({ recordCheck, rewrite, checkedSessionId, complete });
+  return Object.freeze({
+    recordCheck,
+    reserve,
+    beginFetch,
+    complete,
+  });
 }

--- a/open-mcp-server.mjs
+++ b/open-mcp-server.mjs
@@ -2058,11 +2058,30 @@ export function createOpenMcpServer({
     const sessionId = extra ? extractMcpSessionId(extra) : null;
     const identity = oauthVaultIdentityOf(sessionMeta.get(sessionId));
     try {
-      const checkedSessionId = legacyIntentBridge.checkedSessionId({
+      const handoff = legacyIntentBridge.beginFetch({
         identity,
         intentId: args.intentId,
+        maxAmountAtomic: args.maxAmountAtomic,
         sessionId,
       });
+      if (handoff.matched && !handoff.acquired) {
+        const result = sanitizeOpenX402IntentResult({
+          ok: false,
+          intentId: args.intentId,
+          status: 'reconciliation_required',
+          error: 'intent_status_required',
+          reason: 'intent_session_handoff_unavailable',
+          retryable: false,
+          retryWithSameIntentOnly: true,
+        });
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+          isError: true,
+          _meta: FETCH_META,
+        };
+      }
+      const checkedSessionId = handoff.checkedSessionId;
       const result = await x402IntentFetch(args, extra, { checkedSessionId });
       legacyIntentBridge.complete({
         identity,
@@ -3189,14 +3208,19 @@ const httpServer = http.createServer(async (req, res) => {
         }
       }
 
-      const bridged = legacyIntentBridge.rewrite(parsedBody, {
+      const bridged = legacyIntentBridge.reserve(parsedBody, {
         identity: oauthVaultIdentityOf(sessionMeta.get(sessionId)),
         sessionId,
       });
+      parsedBody = bridged.body;
       if (bridged.rewritten) {
-        parsedBody = bridged.body;
         console.log(
           `[open-mcp] translated retired x402_fetch schema `
+          + `sessionRef=${logRef(sessionId)} intentRef=${logRef(bridged.intentId)}`,
+        );
+      } else if (bridged.reserved) {
+        console.log(
+          `[open-mcp] reserved x402 intent session handoff `
           + `sessionRef=${logRef(sessionId)} intentRef=${logRef(bridged.intentId)}`,
         );
       }

--- a/tests/open-legacy-intent-bridge.test.mjs
+++ b/tests/open-legacy-intent-bridge.test.mjs
@@ -50,186 +50,209 @@ function call(args, id = 1) {
   };
 }
 
-test('same OAuth surface rewrites one exact stale fetch to the opaque intent', () => {
-  let clock = Date.parse('2026-08-17T17:00:00.000Z');
-  const bridge = createLegacyIntentBridge({ now: () => clock });
+test('same OAuth surface reserves and begins one exact stale fetch', () => {
+  const bridge = createLegacyIntentBridge({ now: () => Date.parse('2026-08-17T17:00:00.000Z') });
   assert.equal(bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() }), true);
-
   const original = call({ url: URL, method: 'GET', maxAmountAtomic: '50000' });
-  const translated = bridge.rewrite(original, {
-    identity: { ...IDENTITY },
-    sessionId: 'new-mcp-session',
-  });
-  assert.equal(translated.rewritten, true);
-  assert.deepEqual(translated.body.params.arguments, {
-    intentId: 'intent-1',
-    maxAmountAtomic: '50000',
-  });
-  assert.equal(bridge.checkedSessionId({
+  const reserved = bridge.reserve(original, { identity: { ...IDENTITY }, sessionId: 'fetch-session' });
+  assert.equal(reserved.rewritten, true);
+  assert.equal(reserved.reserved, true);
+  assert.deepEqual(reserved.body.params.arguments, { intentId: 'intent-1', maxAmountAtomic: '50000' });
+  assert.deepEqual(bridge.beginFetch({
     identity: IDENTITY,
     intentId: 'intent-1',
-    sessionId: 'new-mcp-session',
-  }), CHECK_SESSION);
-  assert.equal(bridge.checkedSessionId({
-    identity: OTHER_IDENTITY,
-    intentId: 'intent-1',
-    sessionId: 'new-mcp-session',
-  }), null);
-  assert.deepEqual(original.params.arguments, {
-    url: URL,
-    method: 'GET',
     maxAmountAtomic: '50000',
-  });
-
-  // Once claimed, a concurrent/repeated stale call cannot dispatch again.
-  assert.equal(bridge.rewrite(original, {
+    sessionId: 'fetch-session',
+  }), { matched: true, acquired: true, checkedSessionId: CHECK_SESSION });
+  assert.equal(bridge.reserve(original, {
     identity: IDENTITY,
-    sessionId: 'new-mcp-session',
-  }).rewritten, false);
-  clock += 1;
+    sessionId: 'fetch-session',
+  }).reserved, false);
+  assert.equal(bridge.beginFetch({
+    identity: IDENTITY,
+    intentId: 'intent-1',
+    maxAmountAtomic: '50000',
+    sessionId: 'fetch-session',
+  }).acquired, false);
 });
 
-test('known pre-dispatch authorization releases only the same claimed intent', () => {
-  const bridge = createLegacyIntentBridge({
-    now: () => Date.parse('2026-08-17T17:00:00.000Z'),
-  });
+test('canonical fetch reserves after a session change and begins exactly once', () => {
+  const bridge = createLegacyIntentBridge({ now: () => Date.parse('2026-08-17T17:00:00.000Z') });
   bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
-  const original = call({ url: URL, maxAmountAtomic: '50000' });
-  const first = bridge.rewrite(original, {
-    identity: IDENTITY,
-    sessionId: 'session-a',
+  const canonical = call({ intentId: 'intent-1', maxAmountAtomic: '50000' });
+  const reserved = bridge.reserve(canonical, { identity: IDENTITY, sessionId: 'fetch-session' });
+  assert.deepEqual(reserved, {
+    body: canonical,
+    matched: true,
+    reserved: true,
+    rewritten: false,
+    intentId: 'intent-1',
   });
-  assert.equal(first.rewritten, true);
-  assert.equal(bridge.complete({
+  assert.deepEqual(bridge.beginFetch({
     identity: IDENTITY,
     intentId: 'intent-1',
-    sessionId: 'session-a',
-    result: {
-      status: 'authorization_required',
-      authorizationRequired: true,
-      retryWithSameIntentOnly: true,
-    },
-  }), true);
-  assert.equal(bridge.rewrite(original, {
+    maxAmountAtomic: '50000',
+    sessionId: 'fetch-session',
+  }), { matched: true, acquired: true, checkedSessionId: CHECK_SESSION });
+  assert.equal(bridge.beginFetch({
     identity: IDENTITY,
-    sessionId: 'session-b',
-  }).rewritten, true);
+    intentId: 'intent-1',
+    maxAmountAtomic: '50000',
+    sessionId: 'fetch-session',
+  }).acquired, false);
 });
 
-test('success, error, or uncertainty consumes the bridge record', () => {
-  for (const result of [
-    { status: 'complete', ok: true },
-    { status: 'authorization_required', authorizationRequired: true },
-    null,
-  ]) {
-    const bridge = createLegacyIntentBridge({
-      now: () => Date.parse('2026-08-17T17:00:00.000Z'),
-    });
-    bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
-    const original = call({ url: URL, maxAmountAtomic: '50000' });
-    assert.equal(bridge.rewrite(original, {
-      identity: IDENTITY,
-      sessionId: 'session-a',
-    }).rewritten, true);
-    bridge.complete({ identity: IDENTITY, intentId: 'intent-1', sessionId: 'session-a', result });
-    assert.equal(bridge.rewrite(original, {
-      identity: IDENTITY,
-      sessionId: 'session-b',
-    }).rewritten, false);
-  }
-});
-
-test('identity, exact request bytes, and quoted amount are all hard bindings', () => {
-  const bridge = createLegacyIntentBridge({
-    now: () => Date.parse('2026-08-17T17:00:00.000Z'),
-  });
+test('identity, intent, amount, reservation session, and request bytes are hard bindings', () => {
+  const bridge = createLegacyIntentBridge({ now: () => Date.parse('2026-08-17T17:00:00.000Z') });
   bridge.recordCheck({
     identity: IDENTITY,
     sessionId: CHECK_SESSION,
     modelResult: checked({ method: 'POST', body: '{"q":"exact"}' }),
   });
-  const variants = [
-    [OTHER_IDENTITY, { url: URL, method: 'POST', body: '{"q":"exact"}', maxAmountAtomic: '50000' }],
-    [IDENTITY, { url: `${URL}&extra=1`, method: 'POST', body: '{"q":"exact"}', maxAmountAtomic: '50000' }],
-    [IDENTITY, { url: URL, method: 'PUT', body: '{"q":"exact"}', maxAmountAtomic: '50000' }],
-    [IDENTITY, { url: URL, method: 'POST', body: '{"q": "exact"}', maxAmountAtomic: '50000' }],
-    [IDENTITY, { url: URL, method: 'POST', body: '{"q":"exact"}', maxAmountAtomic: '50001' }],
-    [IDENTITY, { url: URL, method: 'POST', body: '{"q":"exact"}', maxAmountAtomic: '50000', purchase: {} }],
-  ];
-  for (const [identity, args] of variants) {
-    assert.equal(bridge.rewrite(call(args), {
-      identity,
-      sessionId: 'session-a',
-    }).rewritten, false);
+  const canonical = call({ intentId: 'intent-1', maxAmountAtomic: '50000' });
+  for (const identity of [
+    OTHER_IDENTITY,
+    { ...IDENTITY, subject: 'user-2' },
+    { ...IDENTITY, issuer: 'https://issuer.example' },
+    { ...IDENTITY, audience: 'https://resource.example/mcp' },
+  ]) {
+    assert.equal(bridge.reserve(canonical, { identity, sessionId: 'session-a' }).matched, false);
   }
-  assert.equal(bridge.rewrite(call({
-    url: URL,
-    method: 'POST',
-    body: '{"q":"exact"}',
-    maxAmountAtomic: '50000',
-  }), {
+  assert.equal(bridge.reserve(call({ intentId: 'intent-x', maxAmountAtomic: '50000' }), {
     identity: IDENTITY,
     sessionId: 'session-a',
-  }).rewritten, true);
+  }).matched, false);
+  assert.deepEqual(bridge.reserve(call({ intentId: 'intent-1', maxAmountAtomic: '50001' }), {
+    identity: IDENTITY,
+    sessionId: 'session-a',
+  }), {
+    body: call({ intentId: 'intent-1', maxAmountAtomic: '50001' }),
+    matched: true,
+    reserved: false,
+    rewritten: false,
+    intentId: 'intent-1',
+  });
+  const exact = call({ url: URL, method: 'POST', body: '{"q":"exact"}', maxAmountAtomic: '50000' });
+  assert.equal(bridge.reserve(exact, { identity: IDENTITY, sessionId: 'session-a' }).reserved, true);
+  assert.equal(bridge.beginFetch({
+    identity: IDENTITY,
+    intentId: 'intent-1',
+    maxAmountAtomic: '50000',
+    sessionId: 'session-b',
+  }).acquired, false);
 });
 
-test('ambiguous, expired, quote-only, or multi-call inputs fail closed', () => {
+test('ambiguous, expired, quote-only, malformed, and batch inputs fail closed', () => {
   let clock = Date.parse('2026-08-17T17:00:00.000Z');
   const bridge = createLegacyIntentBridge({ now: () => clock });
-  assert.equal(bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() }), true);
-  assert.equal(bridge.recordCheck({
-    identity: IDENTITY,
-    sessionId: CHECK_SESSION,
-    modelResult: checked({ intentId: 'intent-2' }),
-  }), false);
-  const stale = call({ url: URL, maxAmountAtomic: '50000' });
-  assert.equal(bridge.rewrite(stale, {
+  bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
+  bridge.recordCheck({ identity: IDENTITY, sessionId: 'check-2', modelResult: checked({ intentId: 'intent-2' }) });
+  assert.equal(bridge.reserve(call({ url: URL, maxAmountAtomic: '50000' }), {
     identity: IDENTITY,
     sessionId: 'session-a',
-  }).rewritten, false);
+  }).reserved, false);
+  assert.equal(bridge.reserve(call({ intentId: 'intent-2', maxAmountAtomic: '50000' }), {
+    identity: IDENTITY,
+    sessionId: 'session-a',
+  }).reserved, true);
 
   const expired = createLegacyIntentBridge({ now: () => clock });
   expired.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
   clock = Date.parse('2026-08-17T17:02:00.001Z');
-  assert.equal(expired.rewrite(stale, {
+  assert.equal(expired.reserve(call({ intentId: 'intent-1', maxAmountAtomic: '50000' }), {
     identity: IDENTITY,
     sessionId: 'session-a',
-  }).rewritten, false);
+  }).matched, false);
 
   const quoteOnly = checked();
   quoteOnly.quoteOnly = true;
   assert.equal(expired.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: quoteOnly }), false);
-
-  const batch = createLegacyIntentBridge({
-    now: () => Date.parse('2026-08-17T17:00:00.000Z'),
-  });
-  batch.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
-  const body = [stale, call({ url: URL, maxAmountAtomic: '50000' }, 2)];
-  assert.equal(batch.rewrite(body, {
+  const batch = [
+    call({ intentId: 'intent-1', maxAmountAtomic: '50000' }),
+    call({ intentId: 'intent-1', maxAmountAtomic: '50000' }, 2),
+  ];
+  assert.equal(bridge.reserve(batch, { identity: IDENTITY, sessionId: 'batch-session' }).reserved, false);
+  assert.equal(bridge.beginFetch({
+    identity: IDENTITY,
+    intentId: 'intent-1',
+    maxAmountAtomic: '50000',
+    sessionId: 'batch-session',
+  }).acquired, false);
+  assert.equal(bridge.reserve(call({ intentId: 'intent-1', maxAmountAtomic: '50000', url: URL }), {
     identity: IDENTITY,
     sessionId: 'session-a',
-  }).rewritten, false);
-
-  const invalidSession = createLegacyIntentBridge({ now: () => clock });
-  assert.equal(invalidSession.recordCheck({
-    identity: IDENTITY,
-    sessionId: 'session with spaces',
-    modelResult: checked(),
-  }), false);
+  }).matched, false);
 });
 
-test('canonical intent calls are never rewritten or claimed', () => {
-  const bridge = createLegacyIntentBridge({
-    now: () => Date.parse('2026-08-17T17:00:00.000Z'),
-  });
+test('canonical and legacy callers race to one reservation and one acquire', () => {
+  const bridge = createLegacyIntentBridge({ now: () => Date.parse('2026-08-17T17:00:00.000Z') });
   bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
-  const canonical = call({ intentId: 'intent-1', maxAmountAtomic: '50000' });
-  assert.deepEqual(bridge.rewrite(canonical, {
+  assert.equal(bridge.reserve(call({ intentId: 'intent-1', maxAmountAtomic: '50000' }), {
     identity: IDENTITY,
-    sessionId: 'session-a',
-  }), { body: canonical, rewritten: false });
-  assert.equal(bridge.rewrite(call({ url: URL, maxAmountAtomic: '50000' }), {
+    sessionId: 'canonical-session',
+  }).reserved, true);
+  assert.equal(bridge.reserve(call({ url: URL, maxAmountAtomic: '50000' }), {
     identity: IDENTITY,
-    sessionId: 'session-a',
-  }).rewritten, true);
+    sessionId: 'legacy-session',
+  }).reserved, false);
+  assert.equal(bridge.beginFetch({
+    identity: IDENTITY,
+    intentId: 'intent-1',
+    maxAmountAtomic: '50000',
+    sessionId: 'canonical-session',
+  }).acquired, true);
+  assert.equal(bridge.beginFetch({
+    identity: IDENTITY,
+    intentId: 'intent-1',
+    maxAmountAtomic: '50000',
+    sessionId: 'legacy-session',
+  }).acquired, false);
+});
+
+test('canonical fetch also reserves when Codex preserves the checked session', () => {
+  const bridge = createLegacyIntentBridge({ now: () => Date.parse('2026-08-17T17:00:00.000Z') });
+  bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
+  assert.equal(bridge.reserve(call({ intentId: 'intent-1', maxAmountAtomic: '50000' }), {
+    identity: IDENTITY,
+    sessionId: CHECK_SESSION,
+  }).reserved, true);
+  assert.deepEqual(bridge.beginFetch({
+    identity: IDENTITY,
+    intentId: 'intent-1',
+    maxAmountAtomic: '50000',
+    sessionId: CHECK_SESSION,
+  }), { matched: true, acquired: true, checkedSessionId: CHECK_SESSION });
+});
+
+test('typed authorization reopens; success, error, and uncertainty consume', () => {
+  const outcomes = [
+    [{ status: 'authorization_required', authorizationRequired: true, retryWithSameIntentOnly: true }, true],
+    [{ status: 'complete', ok: true }, false],
+    [{ status: 'authorization_required', authorizationRequired: true }, false],
+    [null, false],
+  ];
+  for (const [result, reopens] of outcomes) {
+    const bridge = createLegacyIntentBridge({ now: () => Date.parse('2026-08-17T17:00:00.000Z') });
+    bridge.recordCheck({ identity: IDENTITY, sessionId: CHECK_SESSION, modelResult: checked() });
+    bridge.reserve(call({ intentId: 'intent-1', maxAmountAtomic: '50000' }), {
+      identity: IDENTITY,
+      sessionId: 'session-a',
+    });
+    bridge.beginFetch({
+      identity: IDENTITY,
+      intentId: 'intent-1',
+      maxAmountAtomic: '50000',
+      sessionId: 'session-a',
+    });
+    assert.equal(bridge.complete({
+      identity: IDENTITY,
+      intentId: 'intent-1',
+      sessionId: 'session-a',
+      result,
+    }), true);
+    assert.equal(bridge.reserve(call({ intentId: 'intent-1', maxAmountAtomic: '50000' }), {
+      identity: IDENTITY,
+      sessionId: 'session-b',
+    }).reserved, reopens);
+  }
 });

--- a/tests/x402-money-boundary.test.mjs
+++ b/tests/x402-money-boundary.test.mjs
@@ -34,7 +34,10 @@ test('public fetch accepts exactly opaque intent and approved ceiling', () => {
     /\b(?:url|method|body|multipart|tab|purchase|route|payTo|asset|network|challenge):/,
   );
   assert.match(source, /x402IntentFetch\(args, extra, \{ checkedSessionId \}\)/);
-  assert.match(source, /legacyIntentBridge\.checkedSessionId/);
+  assert.match(source, /legacyIntentBridge\.beginFetch/);
+  assert.match(source, /intent_session_handoff_unavailable/);
+  assert.match(source, /intent_status_required/);
+  assert.match(source, /retryWithSameIntentOnly:\s*true/);
   assert.doesNotMatch(source, /x402Fetch\(args, extra\)/);
 });
 
@@ -86,16 +89,20 @@ test('intent handlers never expose caller-carried route or prepared JSON', () =>
 test('retired fetch compatibility runs only after OAuth proof and preserves the checked session', () => {
   const rawStart = serverSource.indexOf('const protectedCall = findVaultProtectedToolCall');
   const verified = serverSource.indexOf('if (verification.ok)', rawStart);
-  const rewrite = serverSource.indexOf('legacyIntentBridge.rewrite(parsedBody', rawStart);
-  const dispatch = serverSource.indexOf('transport.handleRequest(req, res, parsedBody)', rewrite);
+  const reserve = serverSource.indexOf('legacyIntentBridge.reserve(parsedBody', rawStart);
+  const dispatch = serverSource.indexOf('transport.handleRequest(req, res, parsedBody)', reserve);
   assert.ok(rawStart >= 0 && verified > rawStart, 'OAuth boundary missing');
-  assert.ok(rewrite > verified, 'legacy rewrite must follow current Bearer verification');
-  assert.ok(dispatch > rewrite, 'legacy rewrite must precede SDK input validation/dispatch');
+  assert.ok(reserve > verified, 'intent reservation must follow current Bearer verification');
+  assert.ok(dispatch > reserve, 'intent reservation must precede SDK input validation/dispatch');
 
   const source = registration('x402_fetch', 'x402_status');
   assert.match(source, /oauthVaultIdentityOf\(sessionMeta\.get\(sessionId\)\)/);
-  assert.match(source, /legacyIntentBridge\.checkedSessionId\(\{\s*identity,/);
+  assert.match(source, /legacyIntentBridge\.beginFetch\(\{\s*identity,/);
   assert.match(source, /x402IntentFetch\(args, extra, \{ checkedSessionId \}\)/);
+  const begin = source.indexOf('legacyIntentBridge.beginFetch');
+  const refused = source.indexOf('handoff.matched && !handoff.acquired', begin);
+  const api = source.indexOf('x402IntentFetch(args, extra', refused);
+  assert.ok(begin >= 0 && refused > begin && api > refused, 'refused reservation must return before API fetch');
 
   const fetchFunction = serverSource.slice(
     serverSource.indexOf('async function x402IntentFetch'),


### PR DESCRIPTION
Preserves the exact authenticated check session across Codex Apps tool-session churn without changing the public x402 schema or weakening API authority. Exact OAuth identity, intent, amount, TTL, and one-shot reservation are enforced. Focused tests 13/13, open-release typecheck, syntax, descriptor proof, diff-check, and independent P0/P1 review are green.