### PR TITLE
chore: bind OpenDexter to API 66af release

### DIFF
--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -16,15 +16,15 @@
     },
     "integratedApiRelease": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "42c2a81bc35835e50d4c18179c47494a58e1bfb6",
-      "tree": "ddaabed6b70e4af9d204db0623ed677285a91015",
+      "commit": "66afc8ac707146efc827a7d2a7039f177542a331",
+      "tree": "6fbe9fc54a6cb8e8d4a3e0e13b3337dc11980fdb",
       "governedContractCommit": "6c243154e9e06f4e40830300c4027721645a33cc",
       "governedContractTree": "ce2976ada70af9234291aa6a472b3d96a7a84989"
     },
     "portfolioProjection": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "42c2a81bc35835e50d4c18179c47494a58e1bfb6",
-      "tree": "ddaabed6b70e4af9d204db0623ed677285a91015",
+      "commit": "66afc8ac707146efc827a7d2a7039f177542a331",
+      "tree": "6fbe9fc54a6cb8e8d4a3e0e13b3337dc11980fdb",
       "sourcePaths": [
         "src/portfolio/approvedActionTargets.ts",
         "src/routes/passkeyMcpBinding.ts",

--- a/release/opendexter-accepted-production.json
+++ b/release/opendexter-accepted-production.json
@@ -4,12 +4,12 @@
   "api": {
     "endpoint": "https://api.dexter.cash/health",
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "releaseId": "42c2a81bc358-73a292c396a7c51d-4db7cccbd774",
-    "sourceCommit": "42c2a81bc35835e50d4c18179c47494a58e1bfb6",
-    "sourceTree": "ddaabed6b70e4af9d204db0623ed677285a91015",
-    "toolingCommit": "42c2a81bc35835e50d4c18179c47494a58e1bfb6",
-    "artifactSha256": "73a292c396a7c51de55e0b53f63ace8f4c9b795dee6bd950096ab0bd86563ba5",
-    "metadataBindingSha256": "4525234092fd3d0a1ec620fac79665f2b23e39242ebf9b04c3405564593b1f2c"
+    "releaseId": "66afc8ac7071-e34487bb1bbf2232-4db7cccbd774",
+    "sourceCommit": "66afc8ac707146efc827a7d2a7039f177542a331",
+    "sourceTree": "6fbe9fc54a6cb8e8d4a3e0e13b3337dc11980fdb",
+    "toolingCommit": "66afc8ac707146efc827a7d2a7039f177542a331",
+    "artifactSha256": "e34487bb1bbf2232c427c6e9b50834a009701a6ab9f402d53bc80ae3cc98e1c8",
+    "metadataBindingSha256": "d9df3958aef7eb2aff7cbce13403be82cb585ef0b0964fc0d7f162c136d9fdd2"
   },
   "facilitator": {
     "endpoint": "https://x402.dexter.cash/version",

--- a/release/opendexter-source-contracts.json
+++ b/release/opendexter-source-contracts.json
@@ -13,15 +13,15 @@
   },
   "integratedApiRelease": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "42c2a81bc35835e50d4c18179c47494a58e1bfb6",
-    "tree": "ddaabed6b70e4af9d204db0623ed677285a91015",
+    "commit": "66afc8ac707146efc827a7d2a7039f177542a331",
+    "tree": "6fbe9fc54a6cb8e8d4a3e0e13b3337dc11980fdb",
     "governedContractCommit": "6c243154e9e06f4e40830300c4027721645a33cc",
     "governedContractTree": "ce2976ada70af9234291aa6a472b3d96a7a84989"
   },
   "portfolioProjection": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "42c2a81bc35835e50d4c18179c47494a58e1bfb6",
-    "tree": "ddaabed6b70e4af9d204db0623ed677285a91015",
+    "commit": "66afc8ac707146efc827a7d2a7039f177542a331",
+    "tree": "6fbe9fc54a6cb8e8d4a3e0e13b3337dc11980fdb",
     "sourcePaths": [
       "src/portfolio/approvedActionTargets.ts",
       "src/routes/passkeyMcpBinding.ts",


### PR DESCRIPTION
## What changed

- freeze the exact live immutable Dexter API 66af release identity
- derive the integrated API and portfolio projection pins from that receipt
- regenerate the hosted OpenDexter descriptor without changing tools, OAuth, or the 5/12 roster

## Why

The hosted release must attest the API release it actually consumes before the final Native Tab journey proof. The currently live hosted descriptor still pins API 42c.

## Validation

- accepted-production generator completed against API 66af and facilitator fbfa
- exact three-file diff fence passed; facilitator, governed-contract policy, tools, OAuth, and roster are unchanged
- strict cross-repository archived descriptor verifier passed against the remotely advertised branch commit
- focused tests: 37/38 passed; the one failure is a pre-existing bad ref-placement assertion and fails identically in the untouched sealed 25a production release