### PR TITLE
fix: preserve Native Tab consent URLs

### DIFF
--- a/lib/open-x402-intent-api.mjs
+++ b/lib/open-x402-intent-api.mjs
@@ -16,6 +16,13 @@ const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const POSITIVE_ATOMIC_RE = /^[1-9]\d{0,19}$/;
 const OWNER_APPROVAL_PATH_RE =
   /^\/wallet\/approvals\/x402\/[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const NATIVE_TAB_CONSENT_PATH = '/tabs/new';
+// The largest SDK-valid SpendGrantRequest (including the optional 512-char
+// icon and 1024-char callback URLs) encodes below this ceiling. Keep the URL
+// transport bounded while admitting every request the consent page can parse.
+const NATIVE_TAB_REQUEST_MAX_CHARS = 4_096;
+const NATIVE_TAB_REQUEST_RE =
+  /^[A-Za-z0-9_-]+$/;
 const SUPPORTED_METHODS = new Set(['GET', 'POST', 'PUT', 'DELETE']);
 const SERVICE_PROOF_DOMAIN = 'dexter.native-exact.mcp-service.v1';
 const MIN_SERVICE_SECRET_BYTES = 32;
@@ -214,6 +221,36 @@ export function isOpenX402AuthorityRequired(value) {
   ]).has(error);
 }
 
+function isCanonicalNativeTabRequest(value) {
+  if (
+    typeof value !== 'string'
+    || value.length < 1
+    || value.length > NATIVE_TAB_REQUEST_MAX_CHARS
+    || !NATIVE_TAB_REQUEST_RE.test(value)
+    // An unpadded base64url string can never have a one-character tail.
+    || value.length % 4 === 1
+  ) return false;
+  try {
+    return Buffer.from(value, 'base64url').toString('base64url') === value;
+  } catch {
+    return false;
+  }
+}
+
+function isCanonicalNativeTabConsentUrl(candidate, parsed) {
+  if (parsed.pathname !== NATIVE_TAB_CONSENT_PATH) return false;
+  const requests = parsed.searchParams.getAll('req');
+  if (
+    parsed.searchParams.size !== 1
+    || requests.length !== 1
+    || !isCanonicalNativeTabRequest(requests[0])
+  ) return false;
+  // The producer uses URLSearchParams.set with an unpadded base64url value.
+  // Requiring those exact bytes rejects duplicate/extra params, alternate
+  // percent encodings, default-port spellings, and other URL normalizations.
+  return candidate === `${parsed.origin}${NATIVE_TAB_CONSENT_PATH}?req=${requests[0]}`;
+}
+
 export function readOpenX402ConsentUrl(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
@@ -224,8 +261,11 @@ export function readOpenX402ConsentUrl(value) {
     && !Array.isArray(value.approval)
       ? value.approval
       : null;
-  const candidate = typeof value.consentUrl === 'string'
+  const topLevelConsentUrl = typeof value.consentUrl === 'string'
     ? value.consentUrl
+    : null;
+  const candidate = topLevelConsentUrl !== null
+    ? topLevelConsentUrl
     : new Set([
       'dexter-gateway-owner-consent-link/v1',
       'dexter-native-exact-owner-consent-link/v1',
@@ -241,8 +281,14 @@ export function readOpenX402ConsentUrl(value) {
       || parsed.username !== ''
       || parsed.password !== ''
       || parsed.hash !== ''
-      || !OWNER_APPROVAL_PATH_RE.test(parsed.pathname)
     ) return undefined;
+    if (
+      topLevelConsentUrl !== null
+      && isCanonicalNativeTabConsentUrl(candidate, parsed)
+    ) {
+      return candidate;
+    }
+    if (!OWNER_APPROVAL_PATH_RE.test(parsed.pathname)) return undefined;
     const queryless = parsed.searchParams.size === 0;
     const legacyCeilingOnly =
       parsed.searchParams.size === 1
@@ -258,6 +304,46 @@ export function readOpenX402ConsentUrl(value) {
   } catch {
     return undefined;
   }
+}
+
+export function projectOpenX402AuthorizationRequired({
+  intentId,
+  maxAmountAtomic,
+  data,
+}) {
+  const retry = {
+    intentId,
+    ...(maxAmountAtomic ? { maxAmountAtomic } : {}),
+  };
+  const consentUrl = readOpenX402ConsentUrl(data);
+  if (consentUrl) {
+    return sanitizeOpenX402IntentResult({
+      ok: false,
+      intentId,
+      status: 'authorization_required',
+      authorizationRequired: true,
+      consentUrl,
+      retry,
+      reason: typeof data?.error === 'string'
+        ? data.error
+        : 'authorization_required',
+      retryable: false,
+      retryWithSameIntentOnly: true,
+    });
+  }
+  return sanitizeOpenX402IntentResult({
+    ok: false,
+    intentId,
+    status: 'authorization_required',
+    authorizationRequired: true,
+    error: 'hosted_consent_unavailable',
+    reason: typeof data?.error === 'string'
+      ? data.error
+      : 'governed_principal_required',
+    retry,
+    retryable: false,
+    retryWithSameIntentOnly: true,
+  });
 }
 
 function publicDelivery(value) {

--- a/open-mcp-server.mjs
+++ b/open-mcp-server.mjs
@@ -50,7 +50,7 @@ import {
   OPEN_X402_INTENT_API_PATHS,
   callOpenX402IntentApi,
   isOpenX402AuthorityRequired,
-  readOpenX402ConsentUrl,
+  projectOpenX402AuthorizationRequired,
   sanitizeOpenX402IntentResult,
 } from './lib/open-x402-intent-api.mjs';
 import {
@@ -640,40 +640,6 @@ async function resolveIntentSession(extra) {
   };
 }
 
-function intentConsentResult({ intentId, maxAmountAtomic, data }) {
-  const retry = {
-    intentId,
-    ...(maxAmountAtomic ? { maxAmountAtomic } : {}),
-  };
-  const consentUrl = readOpenX402ConsentUrl(data);
-  if (consentUrl) {
-    return sanitizeOpenX402IntentResult({
-      ok: false,
-      intentId,
-      status: 'authorization_required',
-      authorizationRequired: true,
-      consentUrl,
-      retry,
-      reason: typeof data.error === 'string' ? data.error : 'authorization_required',
-      retryable: false,
-      retryWithSameIntentOnly: true,
-    });
-  }
-  return sanitizeOpenX402IntentResult({
-    ok: false,
-    intentId,
-    status: 'authorization_required',
-    authorizationRequired: true,
-    error: 'hosted_consent_unavailable',
-    reason: typeof data?.error === 'string'
-      ? data.error
-      : 'governed_principal_required',
-    retry,
-    retryable: false,
-    retryWithSameIntentOnly: true,
-  });
-}
-
 async function x402IntentFetch(
   { intentId, maxAmountAtomic },
   extra,
@@ -708,8 +674,7 @@ async function x402IntentFetch(
     maxAmountAtomic,
   });
   if (isOpenX402AuthorityRequired(response.data)) {
-    return intentConsentResult({
-      tool: 'x402_fetch',
+    return projectOpenX402AuthorizationRequired({
       intentId,
       maxAmountAtomic,
       data: response.data,
@@ -750,8 +715,7 @@ async function x402IntentStatus({ intentId }, extra) {
     intentId,
   });
   if (isOpenX402AuthorityRequired(response.data)) {
-    return intentConsentResult({
-      tool: 'x402_status',
+    return projectOpenX402AuthorizationRequired({
       intentId,
       data: response.data,
     });

--- a/tests/open-x402-intent-api.test.mjs
+++ b/tests/open-x402-intent-api.test.mjs
@@ -6,6 +6,7 @@ import {
   buildOpenX402IntentRequest,
   callOpenX402IntentApi,
   isOpenX402AuthorityRequired,
+  projectOpenX402AuthorizationRequired,
   readOpenX402ConsentUrl,
   sanitizeOpenX402IntentResult,
 } from '../lib/open-x402-intent-api.mjs';
@@ -223,6 +224,98 @@ test('rail-neutral owner approval becomes one safe hosted-consent continuation',
     Object.hasOwn(sanitizeOpenX402IntentResult(source), 'approval'),
     false,
   );
+});
+
+test('Native Tab consent admits only one bounded canonical req on the exact hosted URL', () => {
+  const req = Buffer.from(JSON.stringify({
+    v: 1,
+    kind: 'dexter.spendGrantRequest',
+  })).toString('base64url');
+  const consentUrl = `https://dexter.cash/tabs/new?req=${req}`;
+
+  assert.equal(readOpenX402ConsentUrl({ consentUrl }), consentUrl);
+  for (const rejected of [
+    'https://dexter.cash/tabs/new',
+    'https://dexter.cash/tabs/new?req=',
+    `https://dexter.cash/tabs/new/?req=${req}`,
+    `https://dexter.cash:443/tabs/new?req=${req}`,
+    `https://dexter.cash/tabs/new?req=${req}&next=x`,
+    `https://dexter.cash/tabs/new?req=${req}&req=${req}`,
+    `https://dexter.cash/tabs/new?req=${encodeURIComponent(req)}`.replace(
+      req,
+      `%${req.charCodeAt(0).toString(16)}${req.slice(1)}`,
+    ),
+    'https://dexter.cash/tabs/new?req=A',
+    `https://dexter.cash/tabs/new?req=${req}=`,
+    `https://dexter.cash/tabs/new?req=${'a'.repeat(4_100)}`,
+    `https://dexter.cash/tabs/new?req=${req}#fragment`,
+    `https://user@dexter.cash/tabs/new?req=${req}`,
+    `https://DEXTER.CASH/tabs/new?req=${req}`,
+    `https://dexter.cash.evil.example/tabs/new?req=${req}`,
+  ]) {
+    assert.equal(readOpenX402ConsentUrl({ consentUrl: rejected }), undefined, rejected);
+  }
+  assert.equal(readOpenX402ConsentUrl({
+    approval: {
+      namespace: 'dexter-native-exact-owner-consent-link/v1',
+      consentUrl,
+    },
+  }), undefined);
+  assert.equal(readOpenX402ConsentUrl({
+    consentUrl: '',
+    approval: {
+      namespace: 'dexter-gateway-owner-consent-link/v1',
+      consentUrl:
+        'https://dexter.cash/wallet/approvals/x402/018f47dd-1f5f-7abc-8def-0123456789ab',
+    },
+  }), undefined);
+});
+
+test('x402_fetch authorization projection exposes the valid Native Tab continuation on the same intent', () => {
+  const req = Buffer.from('{"native":"tab"}').toString('base64url');
+  const consentUrl = `https://dexter.cash/tabs/new?req=${req}`;
+
+  assert.deepEqual(projectOpenX402AuthorizationRequired({
+    intentId: 'intent-native-tab-1',
+    maxAmountAtomic: '50000',
+    data: {
+      ok: false,
+      error: 'authorization_required',
+      consentUrl,
+      sessionId: 'private-provider-session',
+    },
+  }), {
+    ok: false,
+    intentId: 'intent-native-tab-1',
+    status: 'authorization_required',
+    authorizationRequired: true,
+    consentUrl,
+    retry: {
+      intentId: 'intent-native-tab-1',
+      maxAmountAtomic: '50000',
+    },
+    reason: 'authorization_required',
+    retryable: false,
+    retryWithSameIntentOnly: true,
+  });
+});
+
+test('x402_fetch authorization projection fails closed when Native Tab consent is malformed', () => {
+  const result = projectOpenX402AuthorizationRequired({
+    intentId: 'intent-native-tab-1',
+    maxAmountAtomic: '50000',
+    data: {
+      error: 'authorization_required',
+      consentUrl: 'https://dexter.cash/tabs/new?req=not%2Fcanonical',
+    },
+  });
+
+  assert.equal(result.error, 'hosted_consent_unavailable');
+  assert.equal(Object.hasOwn(result, 'consentUrl'), false);
+  assert.deepEqual(result.retry, {
+    intentId: 'intent-native-tab-1',
+    maxAmountAtomic: '50000',
+  });
 });
 
 test('hosted consent rejects lookalike origins and unknown nested contracts', () => {


### PR DESCRIPTION
## Summary

- admit only the exact hosted `https://dexter.cash/tabs/new?req=<canonical-base64url>` continuation
- keep existing owner-approval URL rules unchanged and reject credentials, hashes, duplicate or extra parameters, alternate encodings, and lookalike origins
- project the safe continuation through canonical `x402_fetch` and `x402_status` while preserving same-intent retry binding and stripping private backend fields

## Root cause

The API correctly created a pending Native Tab consent request, but the hosted MCP allowlist recognized only `/wallet/approvals/x402/<uuid>`. It discarded the valid `/tabs/new?req=...` URL and returned `hosted_consent_unavailable`.

## Verification

- relevant boundary suite: 39/39
- independent exact-commit review: 0 P0 / 0 P1
- syntax, runtime workspace build, Apps SDK build, and typecheck green
- broader suite: 605 passed, 1 skipped; one pre-existing source-receipt fixture failure (`refs/heads/integrated` absent)
- `git diff --check`

No API, PM2, wallet, payment, consent, or live-service mutation is included in this source change.