### PR TITLE
fix: reuse a single PrismaClient instead of one per request

### DIFF
--- a/http-server-oauth.mjs
+++ b/http-server-oauth.mjs
@@ -201,6 +201,21 @@ const sessionStartTimes = new Map(); // sessionId -> timestamp (ms)
 const sessionClientHints = new Map(); // sessionId -> inferred client label
 const sessionLastActivity = new Map(); // sessionId -> timestamp (ms) for idle detection
 
+// Shared PrismaClient for the life of the process. PrismaClient opens its own
+// connection pool on first query; the wallet-override seeding below used to
+// instantiate a fresh one per session (and, when no linked wallet was found,
+// per subsequent request in that session) and never called $disconnect(),
+// leaking a Postgres connection pool on every call until the database's
+// max_connections was exhausted. One shared instance is the correct pattern.
+let _prismaClient = null;
+async function getPrismaClient() {
+  if (!_prismaClient) {
+    const { PrismaClient } = await import('@prisma/client');
+    _prismaClient = new PrismaClient();
+  }
+  return _prismaClient;
+}
+
 const SESSION_LABEL_HEADERS = (() => {
   const raw = String(process.env.MCP_SESSION_LABEL_HEADER || '').trim().toLowerCase();
   if (!raw) return [];
@@ -1561,8 +1576,7 @@ const server = http.createServer(async (req, res) => {
             try {
               const { sessionWalletOverrides } = await import('./toolsets/wallet/index.mjs');
               if (!sessionWalletOverrides.get(sessionId)) {
-                const { PrismaClient } = await import('@prisma/client');
-                const prisma = new PrismaClient();
+                const prisma = await getPrismaClient();
                 const link = await prisma.oauth_user_wallets.findFirst({ where: { provider: String(ident.issuer), subject: String(ident.sub), default_wallet: true } });
                 if (link?.wallet_public_key) sessionWalletOverrides.set(sessionId, String(link.wallet_public_key));
               }
@@ -1717,8 +1731,7 @@ const server = http.createServer(async (req, res) => {
           // Seed per-session wallet override from OAuth mapping (if exists)
           try {
             const { sessionWalletOverrides } = await import('./toolsets/wallet/index.mjs');
-            const { PrismaClient } = await import('@prisma/client');
-            const prisma = new PrismaClient();
+            const prisma = await getPrismaClient();
             const ident = sessionIdentity.get(sid) || {};
             const link = ident.issuer && ident.sub ? await prisma.oauth_user_wallets.findFirst({ where: { provider: String(ident.issuer), subject: String(ident.sub), default_wallet: true } }) : null;
             if (link?.wallet_public_key) sessionWalletOverrides.set(sid, String(link.wallet_public_key));


### PR DESCRIPTION
Noticed while reading through the OAuth session flow: the wallet-override seeding path creates a new PrismaClient() on every session init, and again on the existing-session request path if no linked default wallet was found for that identity.

The guard there is `if (!sessionWalletOverrides.get(sessionId))` — when no wallet link is found, that never flips true, so it ends up re-creating the client on every request in that session, not just once.

Since PrismaClient() isn't disconnected anywhere, each of those opens its own connection pool that never gets released. Could add up under enough sessions/requests.

Swapped both spots to share one PrismaClient via a small getPrismaClient() helper next to the other module-level session state. Just a reuse fix, no behavior change. Ran node --check to confirm it's still valid.