### PR TITLE
Finalize sealed OpenDexter descriptors

### DIFF
--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -204,7 +204,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-marketplace-search-0b654c9b",
+          "resourceUri": "ui://dexter/x402-marketplace-search-23910bce",
           "visibility": [
             "model",
             "app"
@@ -224,8 +224,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-marketplace-search-0b654c9b",
-        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-0b654c9b",
+        "ui/resourceUri": "ui://dexter/x402-marketplace-search-23910bce",
+        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-23910bce",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": true,
         "openai/widgetDomain": "https://dexter.cash",
@@ -489,7 +489,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-pricing-259bfcd0",
+          "resourceUri": "ui://dexter/x402-pricing-95890725",
           "visibility": [
             "model",
             "app"
@@ -507,8 +507,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-pricing-259bfcd0",
-        "openai/outputTemplate": "ui://dexter/x402-pricing-259bfcd0",
+        "ui/resourceUri": "ui://dexter/x402-pricing-95890725",
+        "openai/outputTemplate": "ui://dexter/x402-pricing-95890725",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": true,
         "openai/widgetDomain": "https://dexter.cash",
@@ -674,7 +674,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
+          "resourceUri": "ui://dexter/x402-fetch-result-af524c99",
           "visibility": [
             "model",
             "app"
@@ -693,8 +693,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
-        "openai/outputTemplate": "ui://dexter/x402-fetch-result-8996d1b0",
+        "ui/resourceUri": "ui://dexter/x402-fetch-result-af524c99",
+        "openai/outputTemplate": "ui://dexter/x402-fetch-result-af524c99",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": false,
         "openai/widgetDomain": "https://dexter.cash",
@@ -1100,7 +1100,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
+          "resourceUri": "ui://dexter/x402-fetch-result-af524c99",
           "visibility": [
             "model"
           ],
@@ -1118,8 +1118,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
-        "openai/outputTemplate": "ui://dexter/x402-fetch-result-8996d1b0",
+        "ui/resourceUri": "ui://dexter/x402-fetch-result-af524c99",
+        "openai/outputTemplate": "ui://dexter/x402-fetch-result-af524c99",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": false,
         "openai/widgetDomain": "https://dexter.cash",
@@ -1408,7 +1408,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-wallet-e33931ca",
+          "resourceUri": "ui://dexter/x402-wallet-3760bc3b",
           "visibility": [
             "model",
             "app"
@@ -1429,8 +1429,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-wallet-e33931ca",
-        "openai/outputTemplate": "ui://dexter/x402-wallet-e33931ca",
+        "ui/resourceUri": "ui://dexter/x402-wallet-3760bc3b",
+        "openai/outputTemplate": "ui://dexter/x402-wallet-3760bc3b",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": false,
         "openai/widgetDomain": "https://dexter.cash",


### PR DESCRIPTION
The clean Linux materializer identified widget URI hashes that came from a reused macOS build tree. This commit restores the byte-exact URIs produced by a fresh archived install while retaining the accepted API `acf58d17990c` contract.

Evidence:

- generated by Node 22.19.0 and npm 10.9.3 from the clean merged source archive
- changed descriptor passes the Dexter prose gate
- public MCP remains on `495a3b8` until the corrected sealed release passes validation