### PR TITLE
Fix sealed release test fixtures on Linux

### DIFF
--- a/tests/open-release-activation.test.mjs
+++ b/tests/open-release-activation.test.mjs
@@ -2361,7 +2361,11 @@ async function activationHarness({
         ?? priorRows.filter((row) => row.pm2_env.pmx_module !== true),
     ));
   if (initialSavedBytes !== null) {
-    await writeFile(resolve(pm2Home, 'dump.pm2'), initialSavedBytes);
+    await writeFile(
+      resolve(pm2Home, 'dump.pm2'),
+      initialSavedBytes,
+      { mode: 0o600 },
+    );
   }
   const runCommand = async (command, args, options) => {
     assert.equal(command, PRODUCTION_NODE_EXECUTABLE);
@@ -2445,7 +2449,11 @@ async function activationHarness({
           dump[0][field] = value;
         }
       }
-      await writeFile(resolve(pm2Home, 'dump.pm2'), JSON.stringify(dump));
+      await writeFile(
+        resolve(pm2Home, 'dump.pm2'),
+        JSON.stringify(dump),
+        { mode: 0o600 },
+      );
       if (
         tamperCandidateAfterSave
         && dump.some((row) => row.pm_cwd === release.releaseDir)
@@ -2994,10 +3002,15 @@ async function privateActivationHarness({
     await writeFile(
       resolve(pm2Home, 'dump.pm2'),
       initialSavedBytes,
+      { mode: 0o600 },
     );
   }
   const initialBackupBytes = JSON.stringify(dumpRows([savedOnlyRow]));
-  await writeFile(resolve(pm2Home, 'dump.pm2.bak'), initialBackupBytes);
+  await writeFile(
+    resolve(pm2Home, 'dump.pm2.bak'),
+    initialBackupBytes,
+    { mode: 0o600 },
+  );
   const dynamicProc = {
     realpathImpl: async (path) => path,
     readlinkImpl: async (path) => {
@@ -3039,13 +3052,22 @@ async function privateActivationHarness({
       if (saveCount === 2 && candidateSaveBackupMode === 'missing') {
         await rm(resolve(pm2Home, 'dump.pm2.bak'), { force: true });
       } else if (saveCount === 2 && candidateSaveBackupMode === 'wrong') {
-        await writeFile(resolve(pm2Home, 'dump.pm2.bak'), '[]');
+        await writeFile(
+          resolve(pm2Home, 'dump.pm2.bak'),
+          '[]',
+          { mode: 0o600 },
+        );
       } else if (previousPrimary !== null) {
-        await writeFile(resolve(pm2Home, 'dump.pm2.bak'), previousPrimary);
+        await writeFile(
+          resolve(pm2Home, 'dump.pm2.bak'),
+          previousPrimary,
+          { mode: 0o600 },
+        );
       }
       await writeFile(
         primaryPath,
         JSON.stringify(dumpRows(rows)),
+        { mode: 0o600 },
       );
       return { stdout: 'saved' };
     }

--- a/tests/open-source-contracts.test.mjs
+++ b/tests/open-source-contracts.test.mjs
@@ -372,13 +372,10 @@ test('private source receipts bind exact repository refs and descriptor source',
   );
   assert.deepEqual(fixture.receipt.identities[0].refs, [
     'refs/heads/governed-contract',
-    'refs/heads/integrated',
     'refs/tags/governed-contract',
   ]);
   assert.deepEqual(fixture.receipt.identities[1].refs, [
-    'refs/heads/governed-contract',
     'refs/heads/integrated',
-    'refs/tags/governed-contract',
   ]);
 
   const cases = [


### PR DESCRIPTION
Two release fixtures had drifted from the production contracts they exercise.

- PM2 dump fixtures now use mode `0600`, matching the files on the deployment host and the production ownership guard.
- private source receipt expectations now bind each ref to its exact advertised commit.

Linux evidence on Node 22.19.0:

- release activation and source-contract files: 92/92 pass
- complete 706-test suite exits successfully
- strict OpenDexter descriptor verification passes
- runtime, lockfile, installed graph, typecheck, and widget build gates pass