### PR TITLE
fix: both post /stream/shout and get /stream/shout-f... in...

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@tavily/core": "^0.5.12",
     "chalk": "^5.6.2",
     "dotenv": "^16.4.5",
+    "express-rate-limit": "^8.2.1",
     "node-fetch": "^3.3.2",
     "playwright": "^1.48.2",
     "postcss": "^8.5.6",

--- a/src/routes/streamShouts.ts
+++ b/src/routes/streamShouts.ts
@@ -1,12 +1,29 @@
 import type { Express, Request, Response } from 'express';
 import { Prisma } from '@prisma/client';
 import { z } from 'zod';
+import rateLimit from 'express-rate-limit';
 import prisma from '../prisma.js';
 import { logger, style } from '../logger.js';
 import { getSupabaseUserFromAccessToken } from '../utils/supabaseAdmin.js';
 import { getSupabaseUserIdFromRequest } from '../utils/supabase.js';
 
 const log = logger.child('stream.shouts');
+
+const shoutPostLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { ok: false, error: 'rate_limited' },
+});
+
+const shoutFeedLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { ok: false, error: 'rate_limited' },
+});
 
 const SHOUT_LIFESPAN_SECONDS = 5 * 60;
 const MESSAGE_SCHEMA = z
@@ -90,7 +107,7 @@ async function findPrimaryWalletPublicKey(supabaseUserId: string): Promise<strin
 }
 
 export function registerStreamShoutRoutes(app: Express) {
-  app.post('/stream/shout', async (req: Request, res: Response) => {
+  app.post('/stream/shout', shoutPostLimiter, async (req: Request, res: Response) => {
     try {
       const bearerToken = extractBearerToken(req);
       if (!bearerToken) {
@@ -197,7 +214,7 @@ export function registerStreamShoutRoutes(app: Express) {
     }
   });
 
-  app.get('/stream/shout-feed', async (req: Request, res: Response) => {
+  app.get('/stream/shout-feed', shoutFeedLimiter, async (req: Request, res: Response) => {
     try {
       const limitParam = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : undefined;
       const limit = Number.isFinite(limitParam)


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/routes/streamShouts.ts`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/routes/streamShouts.ts:93` |
| **Assessment** | Likely exploitable |

**Description**: Both POST /stream/shout and GET /stream/shout-feed endpoints lack rate limiting controls. Without throttling, attackers can send high-volume requests to exhaust server resources (memory, CPU, database connections), causing denial of service for legitimate users.

## Evidence

**Exploitation scenario**: Attacker uses automated scripts to flood POST /stream/shout with requests, consuming server resources and causing service degradation or complete outage.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This route handler appears to be publicly accessible. This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `src/routes/streamShouts.ts`
- `package.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
