### PR TITLE
Add OAuth-first OpenDexter MCP entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ This repo contains two hosted MCP servers and the shared `@dexterai/x402-core` p
 | **Dexter MCP** (authenticated) | `mcp.dexter.cash/mcp` | Dexter OAuth | Managed wallet, automatic |
 | **OpenDexter MCP** (hosted) | `open.dexter.cash/mcp` | Mixed per tool: public access or OAuth `scope=vault` | Session-bound passkey wallet; explicit user approval |
 
+OpenDexter also exposes the same twelve tools at
+`https://open.dexter.cash/mcp/vault`. That entry point requires OAuth before
+the MCP session starts. Use it in hosts that cannot complete a protected-tool
+challenge after connecting anonymously. Its tokens are issued for the exact
+`/mcp/vault` resource and cannot be replayed against `/mcp`.
+
 The npm packages (`@dexterai/opendexter`, `@dexterai/x402-discovery`) live in [Dexter-DAO/opendexter-ide](https://github.com/Dexter-DAO/opendexter-ide).
 
 This OpenDexter source candidate requires the coordinated internal package
@@ -211,8 +217,9 @@ before asking PM2 to load that config. The launcher rejects symlinks, hard
 links, foreign ownership, permissive modes, and inherited Node loader controls;
 the immutable release itself contains no credential file.
 
-**How wallet identity works.** OAuth authorizes the stable
-`https://open.dexter.cash/mcp` connector. Protected wallet and portfolio calls
+**How wallet identity works.** OAuth authorizes either the mixed
+`https://open.dexter.cash/mcp` resource or the always-protected
+`https://open.dexter.cash/mcp/vault` resource. Protected wallet and portfolio calls
 resolve the durable wallet binding for that authenticated MCP session and the
 stored passkey-vault identity behind it. They do not accept a caller-supplied
 wallet address or user handle. `x402_wallet` reads the bound passkey wallet;

--- a/docs/mcp-three-connectors-playbook.md
+++ b/docs/mcp-three-connectors-playbook.md
@@ -24,7 +24,7 @@ Edit `~/.cursor/mcp.json` and add:
       "url": "https://mcp.dexter.cash/mcp"
     },
     "OpenDexter": {
-      "url": "https://open.dexter.cash/mcp"
+      "url": "https://open.dexter.cash/mcp/vault"
     },
     "dexter-x402": {
       "command": "npx",
@@ -37,7 +37,9 @@ Edit `~/.cursor/mcp.json` and add:
 ### Notes
 
 - For `Dexter`, complete OAuth/login when prompted.
-- `OpenDexter` should not prompt for login.
+- `OpenDexter` opens wallet authorization before connecting. Use
+  `https://open.dexter.cash/mcp` instead when anonymous search must be available
+  before wallet authorization.
 - `dexter-x402` creates/uses a local wallet (typically `~/.dexterai-mcp/wallet.json`).
 
 ---
@@ -47,7 +49,8 @@ Edit `~/.cursor/mcp.json` and add:
 If adding through a hosted MCP connector UI:
 
 - **Dexter URL:** `https://mcp.dexter.cash/mcp`  
-- **OpenDexter URL:** `https://open.dexter.cash/mcp`
+- **OpenDexter URL:** `https://open.dexter.cash/mcp/vault`
+- **OpenDexter public-search URL:** `https://open.dexter.cash/mcp`
 
 The local command MCP (`dexter-x402`) is generally added in local MCP-capable clients (Cursor/Codex/Claude Code), not as a hosted URL connector.
 
@@ -73,11 +76,12 @@ Use this exact 3-tool flow on each connector:
 - Uses authenticated Dexter context.
 - `x402_fetch` should settle canonically when wallet/funds are available.
 
-### OpenDexter (unauthenticated hosted)
+### OpenDexter (hosted)
 
-- No login required.
-- If no local signer is configured, `x402_fetch` can return `session_required` with funding details.
-- After funding + token/session handoff, it proceeds through canonical x402 settlement.
+- `/mcp/vault` authorizes the passkey wallet before the MCP session starts.
+- `/mcp` keeps anonymous search available and asks for wallet authorization when
+  a protected tool is called.
+- After authorization and funding, `x402_fetch` proceeds through canonical x402 settlement.
 
 ### dexter-x402 (local command MCP)
 
@@ -90,7 +94,7 @@ Use this exact 3-tool flow on each connector:
 
 "Add these three MCPs:  
 1) `https://mcp.dexter.cash/mcp` (Dexter, login required),  
-2) `https://open.dexter.cash/mcp` (OpenDexter, no login),  
+2) `https://open.dexter.cash/mcp/vault` (OpenDexter, wallet authorization),
 3) local `npx -y @dexterai/x402-discovery@latest` (dexter-x402).  
 Then run `x402_wallet`, `x402_search` for `nansen`, and `x402_fetch` on a cheap endpoint in each one."
 
@@ -99,6 +103,7 @@ Then run `x402_wallet`, `x402_search` for `nansen`, and `x402_fetch` on a cheap 
 ## Troubleshooting in 30 Seconds
 
 - **OAuth prompt never appears for Dexter:** remove/re-add connector, confirm URL is exactly `https://mcp.dexter.cash/mcp`.
-- **OpenDexter returns `session_required`:** fund session and retry with provided session token.
+- **OpenDexter never opens authorization:** use the exact
+  `https://open.dexter.cash/mcp/vault` URL, remove the old connection, and add it again.
 - **dexter-x402 cannot settle:** fund local wallet and ensure chain/network match the quote requirements.
 - **Same tool names, different behavior:** expected; signer/account model differs across the three connectors.

--- a/lib/open-mcp-manifest.mjs
+++ b/lib/open-mcp-manifest.mjs
@@ -5,6 +5,8 @@ import {
   OPEN_TOOL_NAMES,
 } from './open-tool-contracts.mjs';
 import {
+  OPEN_MCP_AUTH_FIRST_PRM_URL,
+  OPEN_MCP_AUTH_FIRST_RESOURCE,
   OPEN_MCP_AUTHORIZATION_SERVER,
   OPEN_MCP_PRM_URL,
   OPEN_MCP_VAULT_AUDIENCE,
@@ -23,12 +25,21 @@ export function buildOpenMcpManifest() {
     description:
       'OpenDexter discovers and buys x402 APIs, reads the bound Dexter wallet and portfolio, and prepares, executes, checks, reconciles, and lists governed asset intents under reusable bounded mandates. The current integrated runtime supports autonomous governed Buy and Sell; the preserved Send input fails closed at Prepare until its protected executor and recovery are integrated. Tool presence is not capability: the exact Prepare response is authoritative. Approved assets are selected only by canonical server registry ID; enrollment, extension, and owner escalation remain outside model-callable tools, and provider output never authorizes spend.',
     version: OPEN_MCP_VERSION,
+    endpoints: {
+      public: OPEN_MCP_VAULT_AUDIENCE,
+      vault: OPEN_MCP_AUTH_FIRST_RESOURCE,
+    },
     auth: {
       mode: 'mixed',
       protectedResourceMetadata: OPEN_MCP_PRM_URL,
       authorizationServer: OPEN_MCP_AUTHORIZATION_SERVER,
       resource: OPEN_MCP_VAULT_AUDIENCE,
       vaultScope: 'vault',
+      alwaysProtected: {
+        resource: OPEN_MCP_AUTH_FIRST_RESOURCE,
+        protectedResourceMetadata: OPEN_MCP_AUTH_FIRST_PRM_URL,
+        scope: 'vault',
+      },
       protectedTools: OPEN_TOOL_NAMES.filter((name) =>
         OPEN_TOOL_CONTRACTS[name].securitySchemes.every(
           (scheme) => scheme.type !== 'noauth',

--- a/lib/open-session-auth-state.mjs
+++ b/lib/open-session-auth-state.mjs
@@ -45,6 +45,7 @@ function sameOAuthVaultIdentity(left, right) {
 export function createOpenSessionMeta(lastActivity = Date.now()) {
   return {
     lastActivity,
+    mcpResource: null,
     accountBound: false,
     vaultBound: false,
     vaultAuthMode: null,
@@ -62,6 +63,30 @@ export function markAccountBound(meta) {
   const next = meta || createOpenSessionMeta();
   next.accountBound = true;
   return next;
+}
+
+export function openSessionResourceStatus(meta, resource) {
+  if (typeof resource !== 'string' || resource.length === 0) {
+    throw new TypeError('invalid_open_session_resource');
+  }
+  if (!meta?.mcpResource) return 'unpinned';
+  return meta.mcpResource === resource ? 'match' : 'mismatch';
+}
+
+export function pinOpenSessionResource(meta, resource) {
+  const next = meta || createOpenSessionMeta();
+  const status = openSessionResourceStatus(next, resource);
+  if (status === 'mismatch') {
+    throw new Error('open_session_resource_mismatch');
+  }
+  next.mcpResource = resource;
+  return next;
+}
+
+export function openSessionResourceOf(meta) {
+  return typeof meta?.mcpResource === 'string' && meta.mcpResource.length > 0
+    ? meta.mcpResource
+    : null;
 }
 
 export function markVaultAuthMode(meta, authMode) {

--- a/lib/open-tool-auth.mjs
+++ b/lib/open-tool-auth.mjs
@@ -1,6 +1,13 @@
 export const OPEN_MCP_VAULT_AUDIENCE = 'https://open.dexter.cash/mcp';
 export const OPEN_MCP_PRM_URL =
   'https://open.dexter.cash/.well-known/oauth-protected-resource/mcp';
+export const OPEN_MCP_AUTH_FIRST_RESOURCE =
+  'https://open.dexter.cash/mcp/vault';
+export const OPEN_MCP_AUTH_FIRST_PATH = '/mcp/vault';
+export const OPEN_MCP_AUTH_FIRST_PRM_PATH =
+  '/.well-known/oauth-protected-resource/mcp/vault';
+export const OPEN_MCP_AUTH_FIRST_PRM_URL =
+  'https://open.dexter.cash/.well-known/oauth-protected-resource/mcp/vault';
 export const OPEN_MCP_AUTHORIZATION_SERVER = 'https://mcp.dexter.cash/mcp';
 export const OPEN_MCP_AUTHORIZATION_SERVER_METADATA =
   'https://mcp.dexter.cash/.well-known/oauth-authorization-server/mcp';
@@ -16,6 +23,13 @@ export const OPEN_MCP_CHALLENGE_REQUIRED_PARAMETERS = Object.freeze([
 
 export const OPEN_MCP_PRM = Object.freeze({
   resource: OPEN_MCP_VAULT_AUDIENCE,
+  authorization_servers: [OPEN_MCP_AUTHORIZATION_SERVER],
+  scopes_supported: ['vault'],
+  bearer_methods_supported: ['header'],
+});
+
+export const OPEN_MCP_AUTH_FIRST_PRM = Object.freeze({
+  resource: OPEN_MCP_AUTH_FIRST_RESOURCE,
   authorization_servers: [OPEN_MCP_AUTHORIZATION_SERVER],
   scopes_supported: ['vault'],
   bearer_methods_supported: ['header'],
@@ -53,8 +67,21 @@ export function buildOpenMcpAuthorizationServerMetadata(pathname) {
 }
 
 export function isOpenMcpProtectedResourceMetadataPath(pathname) {
-  return pathname === '/.well-known/oauth-protected-resource'
-    || pathname === '/.well-known/oauth-protected-resource/mcp';
+  return OPEN_MCP_PROTECTED_RESOURCE_PATHS.includes(pathname)
+    || pathname === OPEN_MCP_AUTH_FIRST_PRM_PATH;
+}
+
+export function openMcpProtectedResourceMetadataForPath(pathname) {
+  if (pathname === OPEN_MCP_AUTH_FIRST_PRM_PATH) {
+    return OPEN_MCP_AUTH_FIRST_PRM;
+  }
+  if (
+    pathname === '/.well-known/oauth-protected-resource'
+    || pathname === '/.well-known/oauth-protected-resource/mcp'
+  ) {
+    return OPEN_MCP_PRM;
+  }
+  return null;
 }
 
 const NOAUTH = Object.freeze({ type: 'noauth' });
@@ -96,9 +123,10 @@ function authParam(value) {
 export function buildVaultWwwAuthenticate({
   error = null,
   errorDescription = null,
+  resourceMetadataUrl = OPEN_MCP_PRM_URL,
 } = {}) {
   const parameters = [
-    `resource_metadata="${OPEN_MCP_PRM_URL}"`,
+    `resource_metadata="${authParam(resourceMetadataUrl)}"`,
     'scope="vault"',
   ];
   if (error) parameters.push(`error="${authParam(error)}"`);
@@ -109,6 +137,9 @@ export function buildVaultWwwAuthenticate({
 }
 
 export const VAULT_WWW_AUTHENTICATE = buildVaultWwwAuthenticate();
+export const AUTH_FIRST_VAULT_WWW_AUTHENTICATE = buildVaultWwwAuthenticate({
+  resourceMetadataUrl: OPEN_MCP_AUTH_FIRST_PRM_URL,
+});
 
 function requiresVaultOAuth(name) {
   const schemes = OPEN_TOOL_SECURITY_SCHEMES[name];

--- a/lib/open-vault-oauth.mjs
+++ b/lib/open-vault-oauth.mjs
@@ -61,6 +61,13 @@ export async function verifyOpenVaultBearer(
     return invalid('invalid_token');
   }
 
+  // `jose` accepts an audience array when any entry matches. OpenDexter binds
+  // each access token to one exact MCP resource, so multi-audience tokens must
+  // fail even when this resource appears in the array.
+  if (payload?.aud !== audience) {
+    return invalid('invalid_token', 'audience_must_be_one_exact_resource');
+  }
+
   if (!hasRequiredVaultScope(payload)) {
     return invalid('insufficient_scope');
   }

--- a/open-mcp-server.mjs
+++ b/open-mcp-server.mjs
@@ -23,6 +23,7 @@ import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { createRemoteJWKSet } from 'jose';
 import dotenv from 'dotenv';
@@ -107,7 +108,9 @@ import {
 } from './lib/safe-log-fields.mjs';
 import { isWebauthnProbeTelemetryEnabled } from './lib/webauthn-probe-telemetry.mjs';
 import {
-  OPEN_MCP_PRM,
+  OPEN_MCP_AUTH_FIRST_PATH,
+  OPEN_MCP_AUTH_FIRST_PRM_URL,
+  OPEN_MCP_AUTH_FIRST_RESOURCE,
   OPEN_MCP_VAULT_AUDIENCE,
   assertOpenToolAuthPolicyCoverage,
   buildVaultAuthenticationRequired,
@@ -116,6 +119,7 @@ import {
   installCanonicalSecuritySchemeProjection,
   isOpenMcpProtectedResourceMetadataPath,
   isVaultAuthenticationRequired,
+  openMcpProtectedResourceMetadataForPath,
   registerOpenTool,
   vaultAuthenticationReason,
   vaultAuthenticationResult,
@@ -146,8 +150,10 @@ import {
   isVaultBound,
   markAccountBound,
   markVaultBound,
+  openSessionResourceStatus,
   oauthVaultIdentityOf,
   oauthVaultIdentityStatus,
+  pinOpenSessionResource,
   pinOAuthVaultIdentity,
   touchOpenSessionMeta,
 } from './lib/open-session-auth-state.mjs';
@@ -2361,6 +2367,14 @@ function markSessionAccountBound(sessionId) {
   sessionMeta.set(sessionId, markAccountBound(sessionMeta.get(sessionId)));
 }
 
+function pinSessionResource(sessionId, resource) {
+  if (!sessionId) return;
+  sessionMeta.set(
+    sessionId,
+    pinOpenSessionResource(sessionMeta.get(sessionId), resource),
+  );
+}
+
 function markSessionVaultBound(sessionId, authMode = null) {
   if (!sessionId) return;
   sessionMeta.set(sessionId, markVaultBound(sessionMeta.get(sessionId), authMode));
@@ -2431,7 +2445,10 @@ async function seedOAuthVaultBinding(token, payload, identity, sessionId) {
       body: JSON.stringify({ access_token: token, mcp_session_id: sessionId }),
       signal: AbortSignal.timeout(2500),
     });
-    if (res.ok) {
+    const seedAccepted = res.ok;
+    const seedStatus = res.status;
+    await res.body?.cancel().catch(() => undefined);
+    if (seedAccepted) {
       // The seed response may only make the already-pinned OAuth identity
       // routable. It must never replace the session's identity.
       if (
@@ -2449,7 +2466,7 @@ async function seedOAuthVaultBinding(token, payload, identity, sessionId) {
       return true;
     } else {
       console.warn(
-        `[open-mcp] oauth-seed refused status=${res.status} sessionRef=${logRef(sessionId)}`,
+        `[open-mcp] oauth-seed refused status=${seedStatus} sessionRef=${logRef(sessionId)}`,
       );
     }
   } catch (err) {
@@ -2538,8 +2555,16 @@ function readRequestBody(req) {
 // pointer plus scope="vault" (the token claude.ai copies into its authorize
 // request — the Face-ID router). Touches NO session state: the client
 // retries on the same mcp-session-id after completing OAuth.
-function writeVaultChallenge(res, challenge = {}, requestId = null) {
-  const wwwAuthenticate = buildVaultWwwAuthenticate(challenge);
+function writeVaultChallenge(
+  res,
+  challenge = {},
+  requestId = null,
+  resourceMetadataUrl = undefined,
+) {
+  const wwwAuthenticate = buildVaultWwwAuthenticate({
+    ...challenge,
+    ...(resourceMetadataUrl ? { resourceMetadataUrl } : {}),
+  });
   const status = challenge?.error === 'insufficient_scope' ? 403 : 401;
   res.writeHead(status, {
     'Content-Type': 'application/json',
@@ -2925,15 +2950,109 @@ const httpServer = http.createServer(async (req, res) => {
   // pointer in hand). Shape + rationale at OPEN_MCP_PRM's definition.
   if (isOpenMcpProtectedResourceMetadataPath(url.pathname)) {
     res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
-    res.end(JSON.stringify(OPEN_MCP_PRM));
+    res.end(JSON.stringify(openMcpProtectedResourceMetadataForPath(url.pathname)));
     return;
   }
 
-  // Only handle /mcp and root (pathname already normalized for /mcp/<token>)
-  if (pathname !== '/' && pathname !== '/mcp') {
+  // The canonical path remains mixed-auth. /mcp/vault is the same curated
+  // server behind a transport-level OAuth gate for hosts that cannot complete
+  // a runtime challenge after anonymous discovery.
+  const authFirstEntrance = pathname === OPEN_MCP_AUTH_FIRST_PATH;
+  if (pathname !== '/' && pathname !== '/mcp' && !authFirstEntrance) {
     res.writeHead(404, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'Not found' }));
     return;
+  }
+
+  const requestedMcpResource = authFirstEntrance
+    ? OPEN_MCP_AUTH_FIRST_RESOURCE
+    : OPEN_MCP_VAULT_AUDIENCE;
+  const requestSessionId = typeof req.headers['mcp-session-id'] === 'string'
+    ? req.headers['mcp-session-id'].trim()
+    : '';
+
+  // Per-server authorization for the OAuth-first entrance. Every request must
+  // carry an ES256 vault token minted for this exact resource. The canonical
+  // /mcp route keeps its existing mixed per-tool policy and audience.
+  let authFirstAuthorization = null;
+  if (authFirstEntrance) {
+    const bearer = extractBearer(req);
+    const verification = await verifyOpenVaultBearer(bearer, {
+      verificationKey: DEXTER_JWKS,
+      audience: OPEN_MCP_AUTH_FIRST_RESOURCE,
+    });
+    if (!verification.ok) {
+      writeVaultChallenge(
+        res,
+        oauthChallengeForVerification(verification),
+        null,
+        OPEN_MCP_AUTH_FIRST_PRM_URL,
+      );
+      return;
+    }
+    authFirstAuthorization = { bearer, verification };
+  }
+
+  // A session belongs permanently to the exact MCP resource that initialized
+  // it. On the OAuth-first path, verify the Bearer before this comparison so a
+  // caller cannot probe canonical session IDs without authorization.
+  if (requestSessionId && transports.has(requestSessionId)) {
+    const resourceStatus = openSessionResourceStatus(
+      sessionMeta.get(requestSessionId),
+      requestedMcpResource,
+    );
+    if (resourceStatus !== 'match') {
+      res.writeHead(404, {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      });
+      res.end(JSON.stringify({
+        error: 'Session not found for this MCP resource. Re-initialize.',
+      }));
+      return;
+    }
+  }
+
+  if (authFirstAuthorization) {
+    const { bearer, verification } = authFirstAuthorization;
+    if (requestSessionId && transports.has(requestSessionId)) {
+      const identityStatus = oauthVaultIdentityStatus(
+        sessionMeta.get(requestSessionId),
+        verification.identity,
+      );
+      if (identityStatus === 'mismatch') {
+        writeVaultChallenge(res, {
+          error: 'invalid_token',
+          errorDescription:
+            'This OpenDexter authorization belongs to a different session identity; connect again',
+        }, null, OPEN_MCP_AUTH_FIRST_PRM_URL);
+        return;
+      }
+      if (identityStatus === 'unpinned') {
+        pinSessionOAuthIdentity(requestSessionId, verification.identity);
+      }
+      if (!isVaultBound(sessionMeta.get(requestSessionId))) {
+        const seeded = await seedOAuthVaultBinding(
+          bearer,
+          verification.payload,
+          verification.identity,
+          requestSessionId,
+        );
+        if (!seeded) {
+          res.writeHead(503, {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'no-store',
+            'Retry-After': '1',
+          });
+          res.end(JSON.stringify({
+            jsonrpc: '2.0',
+            error: { code: -32603, message: 'Authorization is temporarily unavailable. Retry.' },
+            id: null,
+          }));
+          return;
+        }
+      }
+    }
   }
 
   // ─── GET: SSE / session resume ──────────────────────────────────────
@@ -2988,7 +3107,7 @@ const httpServer = http.createServer(async (req, res) => {
       // Token present but session not yet vault-bound (bind failed at init,
       // or the client added the token mid-session): retry without blocking
       // the in-flight request.
-      if (linkToken && !isVaultBound(sessionMeta.get(sessionId))) {
+      if (!authFirstEntrance && linkToken && !isVaultBound(sessionMeta.get(sessionId))) {
         void bindLinkTokenToSession(linkToken, sessionId);
       }
 
@@ -3047,10 +3166,11 @@ const httpServer = http.createServer(async (req, res) => {
         bearerPresent: Boolean(bearer),
       });
       if (requiresVaultBearer || acceptsOptionalVaultBearer) {
-        const verification = await verifyOpenVaultBearer(bearer, {
-          verificationKey: DEXTER_JWKS,
-          audience: OPEN_MCP_VAULT_AUDIENCE,
-        });
+        const verification = authFirstAuthorization?.verification
+          ?? await verifyOpenVaultBearer(bearer, {
+            verificationKey: DEXTER_JWKS,
+            audience: OPEN_MCP_VAULT_AUDIENCE,
+          });
         if (!verification.ok) {
           console.warn(
             `[open-mcp] rejected vault Bearer (${verification.reason}) for `
@@ -3072,7 +3192,6 @@ const httpServer = http.createServer(async (req, res) => {
             verification.identity,
           );
           if (identityStatus === 'mismatch') {
-            clearSessionVaultBinding(sessionId);
             console.warn(
               `[open-mcp] rejected vault Bearer identity switch for `
               + `${protectedCall?.name || 'optional OAuth promotion'} `
@@ -3163,50 +3282,187 @@ const httpServer = http.createServer(async (req, res) => {
       return;
     }
 
-    const transport = installCanonicalSecuritySchemeProjection(
-      new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-      onsessioninitialized: (sid) => {
-        transports.set(sid, transport);
-        touchSession(sid);
-        if (incomingBinding) {
-          userBindings.set(sid, incomingBinding);
-          markSessionAccountBound(sid);
+    let initialParsedBody;
+    let authFirstSessionId = null;
+    if (authFirstAuthorization) {
+      const accept = String(req.headers.accept || '');
+      if (!accept.includes('application/json') || !accept.includes('text/event-stream')) {
+        res.writeHead(406, {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+        });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          error: {
+            code: -32000,
+            message: 'Not Acceptable: Client must accept both application/json and text/event-stream',
+          },
+          id: null,
+        }));
+        return;
+      }
+      const contentType = String(req.headers['content-type'] || '');
+      if (!contentType.includes('application/json')) {
+        res.writeHead(415, {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+        });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          error: {
+            code: -32000,
+            message: 'Unsupported Media Type: Content-Type must be application/json',
+          },
+          id: null,
+        }));
+        return;
+      }
+      let rawBody;
+      try {
+        rawBody = await readRequestBody(req);
+        initialParsedBody = JSON.parse(rawBody);
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          error: { code: -32700, message: 'Parse error', data: String(err) },
+          id: null,
+        }));
+        return;
+      }
+      if (
+        !isInitializeRequest(initialParsedBody)
+      ) {
+        res.writeHead(400, {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+        });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          error: { code: -32600, message: 'Invalid MCP initialize request.' },
+          id: initialParsedBody?.id ?? null,
+        }));
+        return;
+      }
+
+      authFirstSessionId = randomUUID();
+      touchSession(authFirstSessionId);
+      pinSessionResource(authFirstSessionId, requestedMcpResource);
+      pinSessionOAuthIdentity(
+        authFirstSessionId,
+        authFirstAuthorization.verification.identity,
+      );
+    }
+
+    let transport = null;
+    try {
+      transport = installCanonicalSecuritySchemeProjection(
+        new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => authFirstSessionId ?? randomUUID(),
+        onsessioninitialized: (sid) => {
+          touchSession(sid);
+          pinSessionResource(sid, requestedMcpResource);
+          transports.set(sid, transport);
+          if (authFirstAuthorization) {
+            pinSessionOAuthIdentity(sid, authFirstAuthorization.verification.identity);
+          }
+          if (incomingBinding) {
+            userBindings.set(sid, incomingBinding);
+            markSessionAccountBound(sid);
+            console.log(
+              `[open-mcp] session created ref=${logRef(sid)} `
+              + `(active: ${transports.size}) userRef=${logRef(incomingBinding.userId)}`,
+            );
+          } else {
+            console.log(
+              `[open-mcp] session created ref=${logRef(sid)} (active: ${transports.size})`,
+            );
+          }
+        },
+        }),
+      );
+
+      transport.onclose = () => {
+        const sid = transport.sessionId;
+        if (sid) {
+          transports.delete(sid);
+          userBindings.delete(sid);
+          sessionMeta.delete(sid);
           console.log(
-            `[open-mcp] session created ref=${logRef(sid)} `
-            + `(active: ${transports.size}) userRef=${logRef(incomingBinding.userId)}`,
-          );
-        } else {
-          console.log(
-            `[open-mcp] session created ref=${logRef(sid)} (active: ${transports.size})`,
+            `[open-mcp] session closed ref=${logRef(sid)} (active: ${transports.size})`,
           );
         }
-      },
-      }),
-    );
+      };
 
-    transport.onclose = () => {
-      const sid = transport.sessionId;
-      if (sid) {
-        transports.delete(sid);
-        userBindings.delete(sid);
-        sessionMeta.delete(sid);
-        console.log(
-          `[open-mcp] session closed ref=${logRef(sid)} (active: ${transports.size})`,
+      const mcpServer = createOpenMcpServer();
+      await mcpServer.connect(transport);
+      if (authFirstAuthorization) {
+        const seeded = await seedOAuthVaultBinding(
+          authFirstAuthorization.bearer,
+          authFirstAuthorization.verification.payload,
+          authFirstAuthorization.verification.identity,
+          authFirstSessionId,
         );
+        if (!seeded) {
+          try {
+            await transport.close();
+          } catch {
+            // The maps below remain the authoritative cleanup path.
+          }
+          transports.delete(authFirstSessionId);
+          userBindings.delete(authFirstSessionId);
+          sessionMeta.delete(authFirstSessionId);
+          res.writeHead(503, {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'no-store',
+            'Retry-After': '1',
+          });
+          res.end(JSON.stringify({
+            jsonrpc: '2.0',
+            error: { code: -32603, message: 'Authorization is temporarily unavailable. Retry.' },
+            id: initialParsedBody?.id ?? null,
+          }));
+          return;
+        }
       }
-    };
-
-    const mcpServer = createOpenMcpServer();
-    await mcpServer.connect(transport);
-    await transport.handleRequest(req, res);
-    // Exchange the presented link token for a vault binding on the freshly
-    // created session — response is already written, and the client must
-    // receive it before any tool call arrives, so the binding lands first.
-    if (linkToken && transport.sessionId) {
-      await bindLinkTokenToSession(linkToken, transport.sessionId);
+      await transport.handleRequest(req, res, initialParsedBody);
+      // Exchange the presented link token for a vault binding on the freshly
+      // created session — response is already written, and the client must
+      // receive it before any tool call arrives, so the binding lands first.
+      if (!authFirstEntrance && linkToken && transport.sessionId) {
+        await bindLinkTokenToSession(linkToken, transport.sessionId);
+      }
+      return;
+    } catch (error) {
+      if (!authFirstSessionId) throw error;
+      const provisionalSessionId = transport?.sessionId ?? authFirstSessionId;
+      try {
+        await transport?.close();
+      } catch {
+        // The maps below remain the authoritative cleanup path.
+      }
+      transports.delete(provisionalSessionId);
+      userBindings.delete(provisionalSessionId);
+      sessionMeta.delete(provisionalSessionId);
+      console.warn(
+        `[open-mcp] auth-first initialization failed (${safeErrorLabel(error)})`,
+      );
+      if (!res.headersSent) {
+        res.writeHead(503, {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+          'Retry-After': '1',
+        });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Authorization is temporarily unavailable. Retry.' },
+          id: initialParsedBody?.id ?? null,
+        }));
+      } else if (!res.writableEnded) {
+        res.destroy();
+      }
+      return;
     }
-    return;
   }
 
   // ─── DELETE: close session ──────────────────────────────────────────

--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -204,7 +204,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-marketplace-search-0b654c9b",
+          "resourceUri": "ui://dexter/x402-marketplace-search-23910bce",
           "visibility": [
             "model",
             "app"
@@ -224,8 +224,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-marketplace-search-0b654c9b",
-        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-0b654c9b",
+        "ui/resourceUri": "ui://dexter/x402-marketplace-search-23910bce",
+        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-23910bce",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": true,
         "openai/widgetDomain": "https://dexter.cash",
@@ -489,7 +489,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-pricing-259bfcd0",
+          "resourceUri": "ui://dexter/x402-pricing-95890725",
           "visibility": [
             "model",
             "app"
@@ -507,8 +507,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-pricing-259bfcd0",
-        "openai/outputTemplate": "ui://dexter/x402-pricing-259bfcd0",
+        "ui/resourceUri": "ui://dexter/x402-pricing-95890725",
+        "openai/outputTemplate": "ui://dexter/x402-pricing-95890725",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": true,
         "openai/widgetDomain": "https://dexter.cash",
@@ -674,7 +674,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
+          "resourceUri": "ui://dexter/x402-fetch-result-af524c99",
           "visibility": [
             "model",
             "app"
@@ -693,8 +693,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
-        "openai/outputTemplate": "ui://dexter/x402-fetch-result-8996d1b0",
+        "ui/resourceUri": "ui://dexter/x402-fetch-result-af524c99",
+        "openai/outputTemplate": "ui://dexter/x402-fetch-result-af524c99",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": false,
         "openai/widgetDomain": "https://dexter.cash",
@@ -1100,7 +1100,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
+          "resourceUri": "ui://dexter/x402-fetch-result-af524c99",
           "visibility": [
             "model"
           ],
@@ -1118,8 +1118,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
-        "openai/outputTemplate": "ui://dexter/x402-fetch-result-8996d1b0",
+        "ui/resourceUri": "ui://dexter/x402-fetch-result-af524c99",
+        "openai/outputTemplate": "ui://dexter/x402-fetch-result-af524c99",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": false,
         "openai/widgetDomain": "https://dexter.cash",
@@ -1408,7 +1408,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-wallet-e33931ca",
+          "resourceUri": "ui://dexter/x402-wallet-3760bc3b",
           "visibility": [
             "model",
             "app"
@@ -1429,8 +1429,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-wallet-e33931ca",
-        "openai/outputTemplate": "ui://dexter/x402-wallet-e33931ca",
+        "ui/resourceUri": "ui://dexter/x402-wallet-3760bc3b",
+        "openai/outputTemplate": "ui://dexter/x402-wallet-3760bc3b",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": false,
         "openai/widgetDomain": "https://dexter.cash",

--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -16,15 +16,15 @@
     },
     "integratedApiRelease": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "acf58d17990ce39dc0780cad1ae27641e7202bea",
-      "tree": "67c2b36f91efa84e52bddcbb2a0e1a6daadb91b6",
+      "commit": "e2489332d43c22e034bb87a82657d389db7ce956",
+      "tree": "0574ac140896a846cbd6c08bbf369c1590887b73",
       "governedContractCommit": "fa0701b67625911b8ec97a5399f62ec97a69f976",
       "governedContractTree": "dcee95df1d92018b8fcd8b43645fe63211383274"
     },
     "portfolioProjection": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "acf58d17990ce39dc0780cad1ae27641e7202bea",
-      "tree": "67c2b36f91efa84e52bddcbb2a0e1a6daadb91b6",
+      "commit": "e2489332d43c22e034bb87a82657d389db7ce956",
+      "tree": "0574ac140896a846cbd6c08bbf369c1590887b73",
       "sourcePaths": [
         "src/portfolio/approvedActionTargets.ts",
         "src/routes/passkeyMcpBinding.ts",
@@ -204,7 +204,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-marketplace-search-23910bce",
+          "resourceUri": "ui://dexter/x402-marketplace-search-0b654c9b",
           "visibility": [
             "model",
             "app"
@@ -224,8 +224,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-marketplace-search-23910bce",
-        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-23910bce",
+        "ui/resourceUri": "ui://dexter/x402-marketplace-search-0b654c9b",
+        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-0b654c9b",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": true,
         "openai/widgetDomain": "https://dexter.cash",
@@ -489,7 +489,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-pricing-95890725",
+          "resourceUri": "ui://dexter/x402-pricing-259bfcd0",
           "visibility": [
             "model",
             "app"
@@ -507,8 +507,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-pricing-95890725",
-        "openai/outputTemplate": "ui://dexter/x402-pricing-95890725",
+        "ui/resourceUri": "ui://dexter/x402-pricing-259bfcd0",
+        "openai/outputTemplate": "ui://dexter/x402-pricing-259bfcd0",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": true,
         "openai/widgetDomain": "https://dexter.cash",
@@ -674,7 +674,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-fetch-result-af524c99",
+          "resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
           "visibility": [
             "model",
             "app"
@@ -693,8 +693,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-fetch-result-af524c99",
-        "openai/outputTemplate": "ui://dexter/x402-fetch-result-af524c99",
+        "ui/resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
+        "openai/outputTemplate": "ui://dexter/x402-fetch-result-8996d1b0",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": false,
         "openai/widgetDomain": "https://dexter.cash",
@@ -1100,7 +1100,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-fetch-result-af524c99",
+          "resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
           "visibility": [
             "model"
           ],
@@ -1118,8 +1118,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-fetch-result-af524c99",
-        "openai/outputTemplate": "ui://dexter/x402-fetch-result-af524c99",
+        "ui/resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
+        "openai/outputTemplate": "ui://dexter/x402-fetch-result-8996d1b0",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": false,
         "openai/widgetDomain": "https://dexter.cash",
@@ -1408,7 +1408,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-wallet-3760bc3b",
+          "resourceUri": "ui://dexter/x402-wallet-e33931ca",
           "visibility": [
             "model",
             "app"
@@ -1429,8 +1429,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-wallet-3760bc3b",
-        "openai/outputTemplate": "ui://dexter/x402-wallet-3760bc3b",
+        "ui/resourceUri": "ui://dexter/x402-wallet-e33931ca",
+        "openai/outputTemplate": "ui://dexter/x402-wallet-e33931ca",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": false,
         "openai/widgetDomain": "https://dexter.cash",

--- a/release/opendexter-accepted-production.json
+++ b/release/opendexter-accepted-production.json
@@ -4,12 +4,12 @@
   "api": {
     "endpoint": "https://api.dexter.cash/health",
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "releaseId": "acf58d17990c-1aef59239a0ed3c1-4297dbe748e0",
-    "sourceCommit": "acf58d17990ce39dc0780cad1ae27641e7202bea",
-    "sourceTree": "67c2b36f91efa84e52bddcbb2a0e1a6daadb91b6",
-    "toolingCommit": "acf58d17990ce39dc0780cad1ae27641e7202bea",
-    "artifactSha256": "1aef59239a0ed3c13b7f24664189d9e2969b1060e0b08d4db96f954e4976e8a3",
-    "metadataBindingSha256": "8568ec0f1a6d8288d400a5724ad963a51109f4ec50b2a757f03c727f37710fa2"
+    "releaseId": "e2489332d43c-9203b4b1c2bf6936-4297dbe748e0",
+    "sourceCommit": "e2489332d43c22e034bb87a82657d389db7ce956",
+    "sourceTree": "0574ac140896a846cbd6c08bbf369c1590887b73",
+    "toolingCommit": "e2489332d43c22e034bb87a82657d389db7ce956",
+    "artifactSha256": "9203b4b1c2bf6936ade9ba0d0f1a51ce3669907d11c7911536149ba462de4b9a",
+    "metadataBindingSha256": "6ec66591f4b5014ab60ae368d0fd54bc7fe24c22b7fbb32c10e4ad2fe35629d9"
   },
   "facilitator": {
     "endpoint": "https://x402.dexter.cash/version",

--- a/release/opendexter-dependency-train.json
+++ b/release/opendexter-dependency-train.json
@@ -9,7 +9,7 @@
   "repositories": {
     "hosted": {
       "remote": "https://github.com/Dexter-DAO/dexter-mcp.git",
-      "provenanceCommit": "fb2753f7e9f1e7503d3c61572787decf52499a76"
+      "provenanceCommit": "119d38ebc3bd2bbf440e3b9a1928b76be0a44c8a"
     },
     "opendexter-ide": {
       "remote": "https://github.com/Dexter-DAO/opendexter-ide.git",
@@ -45,7 +45,7 @@
       "source": "hosted",
       "path": "packages/x402-core",
       "entrypoint": "dist/index.js",
-      "treeHash": "1d6d241da3cb38072b8afff012e50e45f84c90f3",
+      "treeHash": "fb0977574fe35fb27b571f6eb708326f122e5848",
       "install": {
         "source": "workspace",
         "release": "workspace"

--- a/release/opendexter-source-contracts.json
+++ b/release/opendexter-source-contracts.json
@@ -13,15 +13,15 @@
   },
   "integratedApiRelease": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "acf58d17990ce39dc0780cad1ae27641e7202bea",
-    "tree": "67c2b36f91efa84e52bddcbb2a0e1a6daadb91b6",
+    "commit": "e2489332d43c22e034bb87a82657d389db7ce956",
+    "tree": "0574ac140896a846cbd6c08bbf369c1590887b73",
     "governedContractCommit": "fa0701b67625911b8ec97a5399f62ec97a69f976",
     "governedContractTree": "dcee95df1d92018b8fcd8b43645fe63211383274"
   },
   "portfolioProjection": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "acf58d17990ce39dc0780cad1ae27641e7202bea",
-    "tree": "67c2b36f91efa84e52bddcbb2a0e1a6daadb91b6",
+    "commit": "e2489332d43c22e034bb87a82657d389db7ce956",
+    "tree": "0574ac140896a846cbd6c08bbf369c1590887b73",
     "sourcePaths": [
       "src/portfolio/approvedActionTargets.ts",
       "src/routes/passkeyMcpBinding.ts",

--- a/tests/open-mcp-manifest.test.mjs
+++ b/tests/open-mcp-manifest.test.mjs
@@ -8,6 +8,8 @@ import {
   OPEN_TOOL_NAMES,
 } from '../lib/open-tool-contracts.mjs';
 import {
+  OPEN_MCP_AUTH_FIRST_PRM_URL,
+  OPEN_MCP_AUTH_FIRST_RESOURCE,
   OPEN_MCP_AUTHORIZATION_SERVER,
   OPEN_MCP_AUTHORIZATION_SERVER_METADATA,
   OPEN_MCP_PRM,
@@ -21,8 +23,17 @@ test('well-known manifest advertises the cumulative five-to-twelve OAuth contrac
   assert.equal(manifest.name, 'OpenDexter');
   assert.equal(manifest.namespace, 'opendexter');
   assert.equal(manifest.url, OPEN_MCP_VAULT_AUDIENCE);
+  assert.deepEqual(manifest.endpoints, {
+    public: OPEN_MCP_VAULT_AUDIENCE,
+    vault: OPEN_MCP_AUTH_FIRST_RESOURCE,
+  });
   assert.equal(manifest.auth.protectedResourceMetadata, OPEN_MCP_PRM_URL);
   assert.equal(manifest.auth.authorizationServer, OPEN_MCP_AUTHORIZATION_SERVER);
+  assert.deepEqual(manifest.auth.alwaysProtected, {
+    resource: OPEN_MCP_AUTH_FIRST_RESOURCE,
+    protectedResourceMetadata: OPEN_MCP_AUTH_FIRST_PRM_URL,
+    scope: 'vault',
+  });
   assert.deepEqual(OPEN_MCP_PRM.scopes_supported, ['vault']);
   assert.deepEqual(
     buildOpenMcpAuthorizationServerMetadata(

--- a/tests/open-release-dependencies.test.mjs
+++ b/tests/open-release-dependencies.test.mjs
@@ -384,7 +384,7 @@ test('hosted source declares one exact internal dependency train', async () => {
   assert.equal(manifest.node, '^20.19.0 || >=22.12.0');
   assert.deepEqual(manifest.repositories.hosted, {
     remote: 'https://github.com/Dexter-DAO/dexter-mcp.git',
-    provenanceCommit: 'fb2753f7e9f1e7503d3c61572787decf52499a76',
+    provenanceCommit: '119d38ebc3bd2bbf440e3b9a1928b76be0a44c8a',
   });
   assert.deepEqual(
     manifest.sourcePackages.map(({ install }) => install),

--- a/tests/open-roster-http.test.mjs
+++ b/tests/open-roster-http.test.mjs
@@ -17,6 +17,10 @@ import {
   OPEN_TOOL_NAMES,
 } from '../lib/open-tool-contracts.mjs';
 import {
+  AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
+  OPEN_MCP_AUTH_FIRST_PRM,
+  OPEN_MCP_AUTH_FIRST_PRM_URL,
+  OPEN_MCP_AUTH_FIRST_RESOURCE,
   OPEN_MCP_VAULT_AUDIENCE,
   VAULT_WWW_AUTHENTICATE,
   buildVaultWwwAuthenticate,
@@ -78,7 +82,7 @@ async function stopChild(child) {
   if (child.exitCode === null) child.kill('SIGKILL');
 }
 
-test('HTTP discovery lists five anonymously and twelve immediately after Bearer initialization', async () => {
+test('mixed HTTP discovery stays public while the exact vault resource authenticates before initialization', async () => {
   const { privateKey, publicKey } = await generateKeyPair('ES256');
   const publicJwk = await exportJWK(publicKey);
   Object.assign(publicJwk, {
@@ -87,19 +91,53 @@ test('HTTP discovery lists five anonymously and twelve immediately after Bearer 
     use: 'sig',
   });
   const now = Math.floor(Date.now() / 1_000);
-  const token = await new SignJWT({
+  const authFirstToken = await new SignJWT({
     scope: 'vault',
     dexter_surface: 'a'.repeat(64),
   })
     .setProtectedHeader({ alg: 'ES256', kid: publicJwk.kid })
     .setIssuer('https://dexter.cash')
-    .setAudience(OPEN_MCP_VAULT_AUDIENCE)
+    .setAudience(OPEN_MCP_AUTH_FIRST_RESOURCE)
     .setSubject('opendexter-roster-test-user')
+    .setIssuedAt(now)
+    .setExpirationTime(now + 300)
+    .sign(privateKey);
+  const authFirstOtherIdentityToken = await new SignJWT({
+    scope: 'vault',
+    dexter_surface: 'd'.repeat(64),
+  })
+    .setProtectedHeader({ alg: 'ES256', kid: publicJwk.kid })
+    .setIssuer('https://dexter.cash')
+    .setAudience(OPEN_MCP_AUTH_FIRST_RESOURCE)
+    .setSubject('opendexter-other-roster-test-user')
+    .setIssuedAt(now)
+    .setExpirationTime(now + 300)
+    .sign(privateKey);
+  const canonicalToken = await new SignJWT({
+    scope: 'vault',
+    dexter_surface: 'b'.repeat(64),
+  })
+    .setProtectedHeader({ alg: 'ES256', kid: publicJwk.kid })
+    .setIssuer('https://dexter.cash')
+    .setAudience(OPEN_MCP_VAULT_AUDIENCE)
+    .setSubject('opendexter-wrong-resource-test-user')
+    .setIssuedAt(now)
+    .setExpirationTime(now + 300)
+    .sign(privateKey);
+  const seedFailureToken = await new SignJWT({
+    scope: 'vault',
+    dexter_surface: 'c'.repeat(64),
+  })
+    .setProtectedHeader({ alg: 'ES256', kid: publicJwk.kid })
+    .setIssuer('https://dexter.cash')
+    .setAudience(OPEN_MCP_AUTH_FIRST_RESOURCE)
+    .setSubject('opendexter-seed-failure-test-user')
     .setIssuedAt(now)
     .setExpirationTime(now + 300)
     .sign(privateKey);
 
   let seedCalls = 0;
+  let failedSeedCalls = 0;
   let seedCompleted = false;
   const dependencyServer = createHttpServer(async (request, response) => {
     try {
@@ -116,10 +154,18 @@ test('HTTP discovery lists five anonymously and twelve immediately after Bearer 
         request.method === 'POST'
         && url.pathname === '/api/passkey-vault/pair/oauth-seed'
       ) {
-        seedCalls += 1;
-        for await (const _chunk of request) {
-          // Consume the body before delaying the response.
+        let rawBody = '';
+        for await (const chunk of request) {
+          rawBody += chunk;
         }
+        const body = JSON.parse(rawBody);
+        if (body.access_token === seedFailureToken) {
+          failedSeedCalls += 1;
+          response.writeHead(503, { 'content-type': 'application/json' });
+          response.end(JSON.stringify({ ok: false }));
+          return;
+        }
+        seedCalls += 1;
         await new Promise((resolve) => setTimeout(resolve, 150));
         seedCompleted = true;
         response.writeHead(200, { 'content-type': 'application/json' });
@@ -161,32 +207,152 @@ test('HTTP discovery lists five anonymously and twelve immediately after Bearer 
   child.stderr.on('data', (chunk) => { output.text += chunk; });
 
   let anonymousClient = null;
+  let anonymousTransport = null;
   let authenticatedClient = null;
+  let authenticatedTransport = null;
   try {
     await waitForStartup(child, openMcpPort, output);
     const mcpUrl = new URL(`http://127.0.0.1:${openMcpPort}/mcp`);
+    const vaultUrl = new URL(`http://127.0.0.1:${openMcpPort}/mcp/vault`);
+
+    const vaultMetadata = await fetch(
+      `http://127.0.0.1:${openMcpPort}/.well-known/oauth-protected-resource/mcp/vault`,
+    );
+    assert.equal(vaultMetadata.status, 200);
+    assert.deepEqual(await vaultMetadata.json(), OPEN_MCP_AUTH_FIRST_PRM);
+
+    const initializeBody = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'auth-first-roster-probe', version: '1.0.0' },
+      },
+    });
+    const unauthenticatedInitialize = await fetch(vaultUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: initializeBody,
+    });
+    assert.equal(unauthenticatedInitialize.status, 401);
+    assert.equal(
+      unauthenticatedInitialize.headers.get('www-authenticate'),
+      AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
+    );
+    assert.match(
+      unauthenticatedInitialize.headers.get('access-control-expose-headers') || '',
+      /WWW-Authenticate/i,
+    );
+
+    const wrongAudienceInitialize = await fetch(vaultUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        Authorization: `Bearer ${canonicalToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: initializeBody,
+    });
+    assert.equal(wrongAudienceInitialize.status, 401);
+    assert.equal(
+      wrongAudienceInitialize.headers.get('www-authenticate'),
+      buildVaultWwwAuthenticate({
+        error: 'invalid_token',
+        errorDescription: 'Connect OpenDexter with a valid vault authorization to continue',
+        resourceMetadataUrl: OPEN_MCP_AUTH_FIRST_PRM_URL,
+      }),
+    );
+
+    const invalidAcceptInitialize = await fetch(vaultUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${authFirstToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: initializeBody,
+    });
+    assert.equal(invalidAcceptInitialize.status, 406);
+    assert.equal(invalidAcceptInitialize.headers.get('mcp-session-id'), null);
+    assert.equal(seedCalls, 0);
+    assert.equal(failedSeedCalls, 0);
+
+    const invalidContentTypeInitialize = await fetch(vaultUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        Authorization: `Bearer ${authFirstToken}`,
+        'Content-Type': 'text/plain',
+      },
+      body: initializeBody,
+    });
+    assert.equal(invalidContentTypeInitialize.status, 415);
+    assert.equal(invalidContentTypeInitialize.headers.get('mcp-session-id'), null);
+    assert.equal(seedCalls, 0);
+    assert.equal(failedSeedCalls, 0);
+
+    const malformedInitialize = await fetch(vaultUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        Authorization: `Bearer ${authFirstToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'initialize',
+        params: {},
+      }),
+    });
+    assert.equal(malformedInitialize.status, 400);
+    assert.equal(malformedInitialize.headers.get('mcp-session-id'), null);
+    assert.equal(seedCalls, 0);
+    assert.equal(failedSeedCalls, 0);
+
+    const unavailableSeed = await fetch(vaultUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        Authorization: `Bearer ${seedFailureToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: initializeBody,
+    });
+    assert.equal(unavailableSeed.status, 503);
+    assert.equal(unavailableSeed.headers.get('mcp-session-id'), null);
+    assert.equal(unavailableSeed.headers.get('retry-after'), '1');
+    assert.equal(seedCalls, 0);
+    assert.equal(failedSeedCalls, 1);
 
     anonymousClient = new Client({
       name: 'anonymous-roster-test',
       version: '1.0.0',
     });
-    await anonymousClient.connect(new StreamableHTTPClientTransport(mcpUrl));
+    anonymousTransport = new StreamableHTTPClientTransport(mcpUrl);
+    await anonymousClient.connect(anonymousTransport);
+    assert.ok(anonymousTransport.sessionId);
     assert.deepEqual(
       (await anonymousClient.listTools()).tools.map(({ name }) => name),
       OPEN_ANONYMOUS_TOOL_NAMES,
     );
-    await closeClient(anonymousClient);
-    anonymousClient = null;
 
     authenticatedClient = new Client({
       name: 'authenticated-roster-test',
       version: '1.0.0',
     });
-    await authenticatedClient.connect(new StreamableHTTPClientTransport(mcpUrl, {
+    authenticatedTransport = new StreamableHTTPClientTransport(vaultUrl, {
       requestInit: {
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { Authorization: `Bearer ${authFirstToken}` },
       },
-    }));
+    });
+    await authenticatedClient.connect(authenticatedTransport);
+    assert.ok(authenticatedTransport.sessionId);
 
     const authenticatedTools = await authenticatedClient.listTools();
     assert.equal(seedCompleted, true, 'tools/list returned before vault binding completed');
@@ -195,6 +361,116 @@ test('HTTP discovery lists five anonymously and twelve immediately after Bearer 
       authenticatedTools.tools.map(({ name }) => name),
       OPEN_TOOL_NAMES,
     );
+
+    const otherIdentityOnSession = await fetch(vaultUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        Authorization: `Bearer ${authFirstOtherIdentityToken}`,
+        'Content-Type': 'application/json',
+        'MCP-Protocol-Version': '2025-06-18',
+        'mcp-session-id': authenticatedTransport.sessionId,
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 90, method: 'tools/list', params: {} }),
+    });
+    assert.equal(otherIdentityOnSession.status, 401);
+    assert.match(
+      otherIdentityOnSession.headers.get('www-authenticate') || '',
+      /error="invalid_token"/,
+    );
+    assert.deepEqual(
+      (await authenticatedClient.listTools()).tools.map(({ name }) => name),
+      OPEN_TOOL_NAMES,
+    );
+    assert.equal(seedCalls, 1, 'foreign identity forced a vault reseed');
+
+    const crossRouteRequest = async ({
+      url,
+      sessionId,
+      method,
+      authorization = null,
+    }) => fetch(url, {
+      method,
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        ...(authorization ? { Authorization: `Bearer ${authorization}` } : {}),
+        'MCP-Protocol-Version': '2025-06-18',
+        'mcp-session-id': sessionId,
+        ...(method === 'POST' ? { 'Content-Type': 'application/json' } : {}),
+      },
+      ...(method === 'POST'
+        ? {
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              id: 91,
+              method: 'tools/list',
+              params: {},
+            }),
+          }
+        : {}),
+    });
+
+    const unauthenticatedCanonicalSessionProbe = await crossRouteRequest({
+      url: vaultUrl,
+      sessionId: anonymousTransport.sessionId,
+      method: 'POST',
+    });
+    assert.equal(unauthenticatedCanonicalSessionProbe.status, 401);
+    assert.equal(
+      unauthenticatedCanonicalSessionProbe.headers.get('www-authenticate'),
+      AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
+    );
+
+    for (const method of ['POST', 'GET', 'DELETE']) {
+      const canonicalSessionOnVault = await crossRouteRequest({
+        url: vaultUrl,
+        sessionId: anonymousTransport.sessionId,
+        method,
+        authorization: authFirstToken,
+      });
+      assert.equal(canonicalSessionOnVault.status, 404, method);
+
+      const vaultSessionOnCanonical = await crossRouteRequest({
+        url: mcpUrl,
+        sessionId: authenticatedTransport.sessionId,
+        method,
+      });
+      assert.equal(vaultSessionOnCanonical.status, 404, method);
+    }
+    assert.equal(seedCalls, 1, 'cross-resource requests mutated the vault binding');
+    assert.deepEqual(
+      (await anonymousClient.listTools()).tools.map(({ name }) => name),
+      OPEN_ANONYMOUS_TOOL_NAMES,
+    );
+    assert.deepEqual(
+      (await authenticatedClient.listTools()).tools.map(({ name }) => name),
+      OPEN_TOOL_NAMES,
+    );
+
+    for (const method of ['POST', 'GET', 'DELETE']) {
+      const missingSessionBearer = await crossRouteRequest({
+        url: vaultUrl,
+        sessionId: authenticatedTransport.sessionId,
+        method,
+      });
+      assert.equal(missingSessionBearer.status, 401, method);
+      assert.equal(
+        missingSessionBearer.headers.get('www-authenticate'),
+        AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
+      );
+    }
+    assert.deepEqual(
+      (await authenticatedClient.listTools()).tools.map(({ name }) => name),
+      OPEN_TOOL_NAMES,
+    );
+
+    const authorizedDelete = await crossRouteRequest({
+      url: vaultUrl,
+      sessionId: authenticatedTransport.sessionId,
+      method: 'DELETE',
+      authorization: authFirstToken,
+    });
+    assert.equal(authorizedDelete.status, 200);
   } finally {
     await closeClient(anonymousClient);
     await closeClient(authenticatedClient);

--- a/tests/open-session-auth-state.test.mjs
+++ b/tests/open-session-auth-state.test.mjs
@@ -15,8 +15,11 @@ import {
   markAccountBound,
   markVaultAuthMode,
   markVaultBound,
+  openSessionResourceOf,
+  openSessionResourceStatus,
   oauthVaultIdentityOf,
   oauthVaultIdentityStatus,
+  pinOpenSessionResource,
   pinOAuthVaultIdentity,
   vaultAuthModeOf,
 } from '../lib/open-session-auth-state.mjs';
@@ -26,6 +29,25 @@ const OAUTH_IDENTITY = Object.freeze({
   surface: 'a'.repeat(64),
   issuer: 'https://dexter.cash',
   audience: 'https://open.dexter.cash/mcp',
+});
+
+const PUBLIC_RESOURCE = 'https://open.dexter.cash/mcp';
+const VAULT_RESOURCE = 'https://open.dexter.cash/mcp/vault';
+
+test('an MCP session is pinned immutably to its initialization resource', () => {
+  const meta = pinOpenSessionResource(
+    createOpenSessionMeta(1),
+    PUBLIC_RESOURCE,
+  );
+
+  assert.equal(openSessionResourceOf(meta), PUBLIC_RESOURCE);
+  assert.equal(openSessionResourceStatus(meta, PUBLIC_RESOURCE), 'match');
+  assert.equal(openSessionResourceStatus(meta, VAULT_RESOURCE), 'mismatch');
+  assert.doesNotThrow(() => pinOpenSessionResource(meta, PUBLIC_RESOURCE));
+  assert.throws(
+    () => pinOpenSessionResource(meta, VAULT_RESOURCE),
+    /open_session_resource_mismatch/,
+  );
 });
 
 test('account authentication remains separate from vault authorization', () => {

--- a/tests/open-tool-auth.test.mjs
+++ b/tests/open-tool-auth.test.mjs
@@ -5,6 +5,11 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import {
+  AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
+  OPEN_MCP_AUTH_FIRST_PRM,
+  OPEN_MCP_AUTH_FIRST_PRM_PATH,
+  OPEN_MCP_AUTH_FIRST_PRM_URL,
+  OPEN_MCP_AUTH_FIRST_RESOURCE,
   OPEN_MCP_AUTHORIZATION_SERVER,
   OPEN_MCP_AUTHORIZATION_SERVER_METADATA,
   OPEN_MCP_CHALLENGE_REQUIRED_PARAMETERS,
@@ -26,6 +31,7 @@ import {
   projectCanonicalSecuritySchemes,
   projectCanonicalSecuritySchemesOnMessage,
   registerOpenTool,
+  openMcpProtectedResourceMetadataForPath,
   vaultAuthenticationReason,
   vaultAuthenticationResult,
   withOpenToolAuth,
@@ -284,14 +290,32 @@ test('OpenDexter authorization metadata helper excludes both legacy discovery ra
   );
 });
 
-test('both protected-resource metadata routes serve the same corrected issuer', () => {
+test('mixed and OAuth-first metadata routes serve exact resource identifiers', () => {
   for (const pathname of [
     '/.well-known/oauth-protected-resource',
     '/.well-known/oauth-protected-resource/mcp',
   ]) {
     assert.equal(isOpenMcpProtectedResourceMetadataPath(pathname), true);
     assert.deepEqual(OPEN_MCP_PRM.authorization_servers, ['https://mcp.dexter.cash/mcp']);
+    assert.equal(openMcpProtectedResourceMetadataForPath(pathname), OPEN_MCP_PRM);
   }
+  assert.equal(
+    openMcpProtectedResourceMetadataForPath(
+      OPEN_MCP_AUTH_FIRST_PRM_PATH,
+    ),
+    OPEN_MCP_AUTH_FIRST_PRM,
+  );
+  assert.equal(OPEN_MCP_AUTH_FIRST_PRM.resource, OPEN_MCP_AUTH_FIRST_RESOURCE);
+  assert.deepEqual(
+    OPEN_MCP_AUTH_FIRST_PRM.authorization_servers,
+    ['https://mcp.dexter.cash/mcp'],
+  );
+  assert.equal(
+    isOpenMcpProtectedResourceMetadataPath(
+      OPEN_MCP_AUTH_FIRST_PRM_PATH,
+    ),
+    true,
+  );
   assert.equal(
     isOpenMcpProtectedResourceMetadataPath('/mcp/.well-known/oauth-protected-resource'),
     false,
@@ -315,6 +339,10 @@ test('runtime challenge is host-native and contains no legacy pairing path', () 
   assert.deepEqual(result.structuredContent, data);
   assert.deepEqual(result._meta['mcp/www_authenticate'], [VAULT_WWW_AUTHENTICATE]);
   assert.match(VAULT_WWW_AUTHENTICATE, new RegExp(`resource_metadata="${OPEN_MCP_PRM_URL}"`));
+  assert.match(
+    AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
+    new RegExp(`resource_metadata="${OPEN_MCP_AUTH_FIRST_PRM_URL}"`),
+  );
   assert.match(VAULT_WWW_AUTHENTICATE, /scope="vault"/);
   assert.doesNotMatch(VAULT_WWW_AUTHENTICATE, /error=/);
   assert.doesNotMatch(VAULT_WWW_AUTHENTICATE, /error_description=/);

--- a/tests/open-vault-oauth.test.mjs
+++ b/tests/open-vault-oauth.test.mjs
@@ -68,6 +68,17 @@ test('accepts vault among multiple space-delimited scopes', async () => {
   assert.equal((await verify(await token({ scope: 'openid vault profile' }))).ok, true);
 });
 
+test('rejects a multi-audience token even when the exact resource is included', async () => {
+  const result = await verify(await token({
+    audience: [AUDIENCE, 'https://open.dexter.cash/mcp/vault'],
+  }));
+  assert.deepEqual(result, {
+    ok: false,
+    reason: 'invalid_token',
+    detail: 'audience_must_be_one_exact_resource',
+  });
+});
+
 test('token refresh keeps one session identity while other valid Bearers mismatch', async () => {
   const first = await verify(await token());
   const meta = pinOAuthVaultIdentity(


### PR DESCRIPTION
Adds the exact `/mcp/vault` resource for clients that require OAuth before MCP initialization while preserving the mixed-access `/mcp` resource.

Includes:
- exact protected-resource metadata and Bearer challenges
- curated 12-tool surface with immutable resource and identity pinning
- standards-based initialization, session handling, and failure cleanup
- production API release receipts and deterministic tool descriptors
- focused route, session, descriptor, and release-gate coverage

Deployment scope: public `dexter-open-mcp` only. The private 63-tool `dexter-mcp` service is outside this change.