### PR TITLE
Accept the vault MCP trailing-slash transport URL

### DIFF
--- a/open-mcp-server.mjs
+++ b/open-mcp-server.mjs
@@ -2957,7 +2957,11 @@ const httpServer = http.createServer(async (req, res) => {
   // The canonical path remains mixed-auth. /mcp/vault is the same curated
   // server behind a transport-level OAuth gate for hosts that cannot complete
   // a runtime challenge after anonymous discovery.
-  const authFirstEntrance = pathname === OPEN_MCP_AUTH_FIRST_PATH;
+  // Some hosted MCP clients normalize a configured URL by appending one
+  // trailing slash before their first initialize request. Treat that spelling
+  // as an HTTP alias while keeping the OAuth resource/audience canonical.
+  const authFirstEntrance = pathname === OPEN_MCP_AUTH_FIRST_PATH
+    || pathname === `${OPEN_MCP_AUTH_FIRST_PATH}/`;
   if (pathname !== '/' && pathname !== '/mcp' && !authFirstEntrance) {
     res.writeHead(404, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'Not found' }));

--- a/tests/open-roster-http.test.mjs
+++ b/tests/open-roster-http.test.mjs
@@ -214,6 +214,7 @@ test('mixed HTTP discovery stays public while the exact vault resource authentic
     await waitForStartup(child, openMcpPort, output);
     const mcpUrl = new URL(`http://127.0.0.1:${openMcpPort}/mcp`);
     const vaultUrl = new URL(`http://127.0.0.1:${openMcpPort}/mcp/vault`);
+    const trailingSlashVaultUrl = new URL(`http://127.0.0.1:${openMcpPort}/mcp/vault/`);
 
     const vaultMetadata = await fetch(
       `http://127.0.0.1:${openMcpPort}/.well-known/oauth-protected-resource/mcp/vault`,
@@ -247,6 +248,20 @@ test('mixed HTTP discovery stays public while the exact vault resource authentic
     assert.match(
       unauthenticatedInitialize.headers.get('access-control-expose-headers') || '',
       /WWW-Authenticate/i,
+    );
+
+    const trailingSlashInitialize = await fetch(trailingSlashVaultUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: initializeBody,
+    });
+    assert.equal(trailingSlashInitialize.status, 401);
+    assert.equal(
+      trailingSlashInitialize.headers.get('www-authenticate'),
+      AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
     );
 
     const wrongAudienceInitialize = await fetch(vaultUrl, {


### PR DESCRIPTION
Cursor Grok Bot normalizes the configured protected endpoint by appending `/` before `initialize`. The canonical `/mcp/vault` route correctly returns the OAuth challenge, while `/mcp/vault/` fell through to the JSON 404.

This treats the one trailing-slash spelling as an HTTP alias while preserving the canonical OAuth resource, audience, protected-resource metadata, and mixed-auth `/mcp` behavior.

Validation:
- exact route regression: passed
- OpenDexter auth policy tests: 19/19 passed
- Open release TypeScript check: passed
- `git diff --check`: passed
- full Linux release gate required before deployment