### PR TITLE
Restore one canonical OpenDexter MCP entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ This repo contains two hosted MCP servers and the shared `@dexterai/x402-core` p
 | **Dexter MCP** (authenticated) | `mcp.dexter.cash/mcp` | Dexter OAuth | Managed wallet, automatic |
 | **OpenDexter MCP** (hosted) | `open.dexter.cash/mcp` | Mixed per tool: public access or OAuth `scope=vault` | Session-bound passkey wallet; explicit user approval |
 
-OpenDexter also exposes the same twelve tools at
-`https://open.dexter.cash/mcp/vault`. That entry point requires OAuth before
-the MCP session starts. Use it in hosts that cannot complete a protected-tool
-challenge after connecting anonymously. Its tokens are issued for the exact
-`/mcp/vault` resource and cannot be replayed against `/mcp`.
-
 The npm packages (`@dexterai/opendexter`, `@dexterai/x402-discovery`) live in [Dexter-DAO/opendexter-ide](https://github.com/Dexter-DAO/opendexter-ide).
 
 This OpenDexter source candidate requires the coordinated internal package
@@ -117,26 +111,26 @@ tools below.
 
 The complete connected roster is:
 
-1. `x402_search`
-2. `x402_check`
-3. `x402_fetch`
-4. `x402_status`
-5. `x402_access`
-6. `x402_wallet`
-7. `dexter_portfolio`
-8. `dexter_prepare_asset_action`
-9. `dexter_execute_asset_action`
-10. `dexter_asset_action_status`
-11. `dexter_reconcile_asset_action`
-12. `dexter_wallet_history`
+1) `x402_search`
+2) `x402_check`
+3) `x402_fetch`
+4) `x402_status`
+5) `x402_access`
+6) `x402_wallet`
+7) `dexter_portfolio`
+8) `dexter_prepare_asset_action`
+9) `dexter_execute_asset_action`
+10) `dexter_asset_action_status`
+11) `dexter_reconcile_asset_action`
+12) `dexter_wallet_history`
 
 The anonymous roster is `x402_search`, `x402_check`, `x402_access`,
 `x402_wallet`, and `dexter_portfolio`. OAuth adds `x402_fetch`, `x402_status`,
 and the five governed-asset tools. Compatibility aliases, composed-skill,
 passkey-probe, and card tools stay outside this hosted roster.
 
-Search never pays. `x402_check` accepts the endpoint URL, method, and optional
-exact raw request-body string. Anonymous checks are quote-only. An
+`x402_check` accepts the endpoint URL, method, and optional exact raw
+request-body string. Anonymous checks are quote-only. An
 authenticated check asks Dexter to custody the request and seller terms and
 returns one opaque `intentId`. `x402_fetch` accepts only that `intentId` and an
 explicit user- or policy-approved `maxAmountAtomic` ceiling. It never accepts
@@ -217,9 +211,8 @@ before asking PM2 to load that config. The launcher rejects symlinks, hard
 links, foreign ownership, permissive modes, and inherited Node loader controls;
 the immutable release itself contains no credential file.
 
-**How wallet identity works.** OAuth authorizes either the mixed
-`https://open.dexter.cash/mcp` resource or the always-protected
-`https://open.dexter.cash/mcp/vault` resource. Protected wallet and portfolio calls
+**How wallet identity works.** OAuth authorizes the mixed
+`https://open.dexter.cash/mcp` resource. Protected wallet and portfolio calls
 resolve the durable wallet binding for that authenticated MCP session and the
 stored passkey-vault identity behind it. They do not accept a caller-supplied
 wallet address or user handle. `x402_wallet` reads the bound passkey wallet;

--- a/docs/mcp-three-connectors-playbook.md
+++ b/docs/mcp-three-connectors-playbook.md
@@ -24,7 +24,7 @@ Edit `~/.cursor/mcp.json` and add:
       "url": "https://mcp.dexter.cash/mcp"
     },
     "OpenDexter": {
-      "url": "https://open.dexter.cash/mcp/vault"
+      "url": "https://open.dexter.cash/mcp"
     },
     "dexter-x402": {
       "command": "npx",
@@ -37,9 +37,8 @@ Edit `~/.cursor/mcp.json` and add:
 ### Notes
 
 - For `Dexter`, complete OAuth/login when prompted.
-- `OpenDexter` opens wallet authorization before connecting. Use
-  `https://open.dexter.cash/mcp` instead when anonymous search must be available
-  before wallet authorization.
+- `OpenDexter` supports public search immediately. It asks for wallet
+  authorization when a protected wallet or payment tool is called.
 - `dexter-x402` creates/uses a local wallet (typically `~/.dexterai-mcp/wallet.json`).
 
 ---
@@ -49,8 +48,7 @@ Edit `~/.cursor/mcp.json` and add:
 If adding through a hosted MCP connector UI:
 
 - **Dexter URL:** `https://mcp.dexter.cash/mcp`  
-- **OpenDexter URL:** `https://open.dexter.cash/mcp/vault`
-- **OpenDexter public-search URL:** `https://open.dexter.cash/mcp`
+- **OpenDexter URL:** `https://open.dexter.cash/mcp`
 
 The local command MCP (`dexter-x402`) is generally added in local MCP-capable clients (Cursor/Codex/Claude Code), not as a hosted URL connector.
 
@@ -78,9 +76,8 @@ Use this exact 3-tool flow on each connector:
 
 ### OpenDexter (hosted)
 
-- `/mcp/vault` authorizes the passkey wallet before the MCP session starts.
-- `/mcp` keeps anonymous search available and asks for wallet authorization when
-  a protected tool is called.
+- Public search is available before wallet authorization.
+- A protected tool call starts wallet authorization when needed.
 - After authorization and funding, `x402_fetch` proceeds through canonical x402 settlement.
 
 ### dexter-x402 (local command MCP)
@@ -94,7 +91,7 @@ Use this exact 3-tool flow on each connector:
 
 "Add these three MCPs:  
 1) `https://mcp.dexter.cash/mcp` (Dexter, login required),  
-2) `https://open.dexter.cash/mcp/vault` (OpenDexter, wallet authorization),
+2) `https://open.dexter.cash/mcp` (OpenDexter),
 3) local `npx -y @dexterai/x402-discovery@latest` (dexter-x402).  
 Then run `x402_wallet`, `x402_search` for `nansen`, and `x402_fetch` on a cheap endpoint in each one."
 
@@ -103,7 +100,8 @@ Then run `x402_wallet`, `x402_search` for `nansen`, and `x402_fetch` on a cheap 
 ## Troubleshooting in 30 Seconds
 
 - **OAuth prompt never appears for Dexter:** remove/re-add connector, confirm URL is exactly `https://mcp.dexter.cash/mcp`.
-- **OpenDexter never opens authorization:** use the exact
-  `https://open.dexter.cash/mcp/vault` URL, remove the old connection, and add it again.
+- **OpenDexter never opens authorization:** call `x402_wallet`, then open the
+  host's OpenDexter settings and choose Authorize or Authenticate if no native
+  authorization action appears.
 - **dexter-x402 cannot settle:** fund local wallet and ensure chain/network match the quote requirements.
 - **Same tool names, different behavior:** expected; signer/account model differs across the three connectors.

--- a/lib/open-mcp-manifest.mjs
+++ b/lib/open-mcp-manifest.mjs
@@ -5,8 +5,6 @@ import {
   OPEN_TOOL_NAMES,
 } from './open-tool-contracts.mjs';
 import {
-  OPEN_MCP_AUTH_FIRST_PRM_URL,
-  OPEN_MCP_AUTH_FIRST_RESOURCE,
   OPEN_MCP_AUTHORIZATION_SERVER,
   OPEN_MCP_PRM_URL,
   OPEN_MCP_VAULT_AUDIENCE,
@@ -25,21 +23,12 @@ export function buildOpenMcpManifest() {
     description:
       'OpenDexter discovers and buys x402 APIs, reads the bound Dexter wallet and portfolio, and prepares, executes, checks, reconciles, and lists governed asset intents under reusable bounded mandates. The current integrated runtime supports autonomous governed Buy and Sell; the preserved Send input fails closed at Prepare until its protected executor and recovery are integrated. Tool presence is not capability: the exact Prepare response is authoritative. Approved assets are selected only by canonical server registry ID; enrollment, extension, and owner escalation remain outside model-callable tools, and provider output never authorizes spend.',
     version: OPEN_MCP_VERSION,
-    endpoints: {
-      public: OPEN_MCP_VAULT_AUDIENCE,
-      vault: OPEN_MCP_AUTH_FIRST_RESOURCE,
-    },
     auth: {
       mode: 'mixed',
       protectedResourceMetadata: OPEN_MCP_PRM_URL,
       authorizationServer: OPEN_MCP_AUTHORIZATION_SERVER,
       resource: OPEN_MCP_VAULT_AUDIENCE,
       vaultScope: 'vault',
-      alwaysProtected: {
-        resource: OPEN_MCP_AUTH_FIRST_RESOURCE,
-        protectedResourceMetadata: OPEN_MCP_AUTH_FIRST_PRM_URL,
-        scope: 'vault',
-      },
       protectedTools: OPEN_TOOL_NAMES.filter((name) =>
         OPEN_TOOL_CONTRACTS[name].securitySchemes.every(
           (scheme) => scheme.type !== 'noauth',

--- a/lib/open-server-instructions.mjs
+++ b/lib/open-server-instructions.mjs
@@ -7,7 +7,7 @@ OpenDexter is Dexter's hosted financial-action layer for a session-bound, self-c
 - Set up, connect, sign in to, authenticate, authorize, or attach a Dexter Wallet or passkey to OpenDexter: call x402_wallet first, before marketplace search or another protected tool.
 - Wallet presence, balance, cash, readiness, deposit address, or recent wallet activity: call x402_wallet.
 - "What's in my wallet?", "show me everything in my wallet", asset inventory, value, or what can currently be sent, bought, or sold: call x402_wallet, then dexter_portfolio after authentication. Compose cash/readiness with governed assets without treating either as execution authority.
-- Find an API or service for a job: call x402_search. Search never pays.
+- Find an API or service for a job: call x402_search.
 - Check a known endpoint, current price, or authentication mode: call x402_check. Checking never approves payment.
 - Pay for or call a paid API: discover when necessary, run the exact check, establish exact authority, then call x402_fetch once. Use x402_status for the same purchase intent after uncertainty or missing finality.
 - Classify a wallet-proof or Sign-In-With-X endpoint: call x402_access. It uses the canonical check path and reports signer availability.

--- a/lib/open-tool-auth.mjs
+++ b/lib/open-tool-auth.mjs
@@ -1,13 +1,6 @@
 export const OPEN_MCP_VAULT_AUDIENCE = 'https://open.dexter.cash/mcp';
 export const OPEN_MCP_PRM_URL =
   'https://open.dexter.cash/.well-known/oauth-protected-resource/mcp';
-export const OPEN_MCP_AUTH_FIRST_RESOURCE =
-  'https://open.dexter.cash/mcp/vault';
-export const OPEN_MCP_AUTH_FIRST_PATH = '/mcp/vault';
-export const OPEN_MCP_AUTH_FIRST_PRM_PATH =
-  '/.well-known/oauth-protected-resource/mcp/vault';
-export const OPEN_MCP_AUTH_FIRST_PRM_URL =
-  'https://open.dexter.cash/.well-known/oauth-protected-resource/mcp/vault';
 export const OPEN_MCP_AUTHORIZATION_SERVER = 'https://mcp.dexter.cash/mcp';
 export const OPEN_MCP_AUTHORIZATION_SERVER_METADATA =
   'https://mcp.dexter.cash/.well-known/oauth-authorization-server/mcp';
@@ -23,13 +16,6 @@ export const OPEN_MCP_CHALLENGE_REQUIRED_PARAMETERS = Object.freeze([
 
 export const OPEN_MCP_PRM = Object.freeze({
   resource: OPEN_MCP_VAULT_AUDIENCE,
-  authorization_servers: [OPEN_MCP_AUTHORIZATION_SERVER],
-  scopes_supported: ['vault'],
-  bearer_methods_supported: ['header'],
-});
-
-export const OPEN_MCP_AUTH_FIRST_PRM = Object.freeze({
-  resource: OPEN_MCP_AUTH_FIRST_RESOURCE,
   authorization_servers: [OPEN_MCP_AUTHORIZATION_SERVER],
   scopes_supported: ['vault'],
   bearer_methods_supported: ['header'],
@@ -67,14 +53,10 @@ export function buildOpenMcpAuthorizationServerMetadata(pathname) {
 }
 
 export function isOpenMcpProtectedResourceMetadataPath(pathname) {
-  return OPEN_MCP_PROTECTED_RESOURCE_PATHS.includes(pathname)
-    || pathname === OPEN_MCP_AUTH_FIRST_PRM_PATH;
+  return OPEN_MCP_PROTECTED_RESOURCE_PATHS.includes(pathname);
 }
 
 export function openMcpProtectedResourceMetadataForPath(pathname) {
-  if (pathname === OPEN_MCP_AUTH_FIRST_PRM_PATH) {
-    return OPEN_MCP_AUTH_FIRST_PRM;
-  }
   if (
     pathname === '/.well-known/oauth-protected-resource'
     || pathname === '/.well-known/oauth-protected-resource/mcp'
@@ -123,10 +105,9 @@ function authParam(value) {
 export function buildVaultWwwAuthenticate({
   error = null,
   errorDescription = null,
-  resourceMetadataUrl = OPEN_MCP_PRM_URL,
 } = {}) {
   const parameters = [
-    `resource_metadata="${authParam(resourceMetadataUrl)}"`,
+    `resource_metadata="${OPEN_MCP_PRM_URL}"`,
     'scope="vault"',
   ];
   if (error) parameters.push(`error="${authParam(error)}"`);
@@ -137,9 +118,6 @@ export function buildVaultWwwAuthenticate({
 }
 
 export const VAULT_WWW_AUTHENTICATE = buildVaultWwwAuthenticate();
-export const AUTH_FIRST_VAULT_WWW_AUTHENTICATE = buildVaultWwwAuthenticate({
-  resourceMetadataUrl: OPEN_MCP_AUTH_FIRST_PRM_URL,
-});
 
 function requiresVaultOAuth(name) {
   const schemes = OPEN_TOOL_SECURITY_SCHEMES[name];

--- a/open-mcp-server.mjs
+++ b/open-mcp-server.mjs
@@ -23,7 +23,6 @@ import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { createRemoteJWKSet } from 'jose';
 import dotenv from 'dotenv';
@@ -108,9 +107,6 @@ import {
 } from './lib/safe-log-fields.mjs';
 import { isWebauthnProbeTelemetryEnabled } from './lib/webauthn-probe-telemetry.mjs';
 import {
-  OPEN_MCP_AUTH_FIRST_PATH,
-  OPEN_MCP_AUTH_FIRST_PRM_URL,
-  OPEN_MCP_AUTH_FIRST_RESOURCE,
   OPEN_MCP_VAULT_AUDIENCE,
   assertOpenToolAuthPolicyCoverage,
   buildVaultAuthenticationRequired,
@@ -2613,16 +2609,8 @@ function readRequestBody(req) {
 // pointer plus scope="vault" (the token claude.ai copies into its authorize
 // request — the Face-ID router). Touches NO session state: the client
 // retries on the same mcp-session-id after completing OAuth.
-function writeVaultChallenge(
-  res,
-  challenge = {},
-  requestId = null,
-  resourceMetadataUrl = undefined,
-) {
-  const wwwAuthenticate = buildVaultWwwAuthenticate({
-    ...challenge,
-    ...(resourceMetadataUrl ? { resourceMetadataUrl } : {}),
-  });
+function writeVaultChallenge(res, challenge = {}, requestId = null) {
+  const wwwAuthenticate = buildVaultWwwAuthenticate(challenge);
   const status = challenge?.error === 'insufficient_scope' ? 403 : 401;
   res.writeHead(status, {
     'Content-Type': 'application/json',
@@ -3012,48 +3000,21 @@ const httpServer = http.createServer(async (req, res) => {
     return;
   }
 
-  // The canonical path remains mixed-auth. /mcp/vault is the same curated
-  // server behind a transport-level OAuth gate for hosts that cannot complete
-  // a runtime challenge after anonymous discovery.
-  const authFirstEntrance = pathname === OPEN_MCP_AUTH_FIRST_PATH;
-  if (pathname !== '/' && pathname !== '/mcp' && !authFirstEntrance) {
+  // OpenDexter has one mixed-auth MCP entrance. Public tools are available
+  // immediately; protected tools trigger OAuth only when invoked.
+  if (pathname !== '/' && pathname !== '/mcp') {
     res.writeHead(404, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'Not found' }));
     return;
   }
 
-  const requestedMcpResource = authFirstEntrance
-    ? OPEN_MCP_AUTH_FIRST_RESOURCE
-    : OPEN_MCP_VAULT_AUDIENCE;
+  const requestedMcpResource = OPEN_MCP_VAULT_AUDIENCE;
   const requestSessionId = typeof req.headers['mcp-session-id'] === 'string'
     ? req.headers['mcp-session-id'].trim()
     : '';
 
-  // Per-server authorization for the OAuth-first entrance. Every request must
-  // carry an ES256 vault token minted for this exact resource. The canonical
-  // /mcp route keeps its existing mixed per-tool policy and audience.
-  let authFirstAuthorization = null;
-  if (authFirstEntrance) {
-    const bearer = extractBearer(req);
-    const verification = await verifyOpenVaultBearer(bearer, {
-      verificationKey: DEXTER_JWKS,
-      audience: OPEN_MCP_AUTH_FIRST_RESOURCE,
-    });
-    if (!verification.ok) {
-      writeVaultChallenge(
-        res,
-        oauthChallengeForVerification(verification),
-        null,
-        OPEN_MCP_AUTH_FIRST_PRM_URL,
-      );
-      return;
-    }
-    authFirstAuthorization = { bearer, verification };
-  }
-
   // A session belongs permanently to the exact MCP resource that initialized
-  // it. On the OAuth-first path, verify the Bearer before this comparison so a
-  // caller cannot probe canonical session IDs without authorization.
+  // it, preventing a session identifier from crossing resource boundaries.
   if (requestSessionId && transports.has(requestSessionId)) {
     const resourceStatus = openSessionResourceStatus(
       sessionMeta.get(requestSessionId),
@@ -3068,48 +3029,6 @@ const httpServer = http.createServer(async (req, res) => {
         error: 'Session not found for this MCP resource. Re-initialize.',
       }));
       return;
-    }
-  }
-
-  if (authFirstAuthorization) {
-    const { bearer, verification } = authFirstAuthorization;
-    if (requestSessionId && transports.has(requestSessionId)) {
-      const identityStatus = oauthVaultIdentityStatus(
-        sessionMeta.get(requestSessionId),
-        verification.identity,
-      );
-      if (identityStatus === 'mismatch') {
-        writeVaultChallenge(res, {
-          error: 'invalid_token',
-          errorDescription:
-            'This OpenDexter authorization belongs to a different session identity; connect again',
-        }, null, OPEN_MCP_AUTH_FIRST_PRM_URL);
-        return;
-      }
-      if (identityStatus === 'unpinned') {
-        pinSessionOAuthIdentity(requestSessionId, verification.identity);
-      }
-      if (!isVaultBound(sessionMeta.get(requestSessionId))) {
-        const seeded = await seedOAuthVaultBinding(
-          bearer,
-          verification.payload,
-          verification.identity,
-          requestSessionId,
-        );
-        if (!seeded) {
-          res.writeHead(503, {
-            'Content-Type': 'application/json',
-            'Cache-Control': 'no-store',
-            'Retry-After': '1',
-          });
-          res.end(JSON.stringify({
-            jsonrpc: '2.0',
-            error: { code: -32603, message: 'Authorization is temporarily unavailable. Retry.' },
-            id: null,
-          }));
-          return;
-        }
-      }
     }
   }
 
@@ -3165,7 +3084,7 @@ const httpServer = http.createServer(async (req, res) => {
       // Token present but session not yet vault-bound (bind failed at init,
       // or the client added the token mid-session): retry without blocking
       // the in-flight request.
-      if (!authFirstEntrance && linkToken && !isVaultBound(sessionMeta.get(sessionId))) {
+      if (linkToken && !isVaultBound(sessionMeta.get(sessionId))) {
         void bindLinkTokenToSession(linkToken, sessionId);
       }
 
@@ -3224,11 +3143,10 @@ const httpServer = http.createServer(async (req, res) => {
         bearerPresent: Boolean(bearer),
       });
       if (requiresVaultBearer || acceptsOptionalVaultBearer) {
-        const verification = authFirstAuthorization?.verification
-          ?? await verifyOpenVaultBearer(bearer, {
-            verificationKey: DEXTER_JWKS,
-            audience: OPEN_MCP_VAULT_AUDIENCE,
-          });
+        const verification = await verifyOpenVaultBearer(bearer, {
+          verificationKey: DEXTER_JWKS,
+          audience: OPEN_MCP_VAULT_AUDIENCE,
+        });
         if (!verification.ok) {
           console.warn(
             `[open-mcp] rejected vault Bearer (${verification.reason}) for `
@@ -3250,6 +3168,7 @@ const httpServer = http.createServer(async (req, res) => {
             verification.identity,
           );
           if (identityStatus === 'mismatch') {
+            clearSessionVaultBinding(sessionId);
             console.warn(
               `[open-mcp] rejected vault Bearer identity switch for `
               + `${protectedCall?.name || 'optional OAuth promotion'} `
@@ -3340,187 +3259,51 @@ const httpServer = http.createServer(async (req, res) => {
       return;
     }
 
-    let initialParsedBody;
-    let authFirstSessionId = null;
-    if (authFirstAuthorization) {
-      const accept = String(req.headers.accept || '');
-      if (!accept.includes('application/json') || !accept.includes('text/event-stream')) {
-        res.writeHead(406, {
-          'Content-Type': 'application/json',
-          'Cache-Control': 'no-store',
-        });
-        res.end(JSON.stringify({
-          jsonrpc: '2.0',
-          error: {
-            code: -32000,
-            message: 'Not Acceptable: Client must accept both application/json and text/event-stream',
-          },
-          id: null,
-        }));
-        return;
-      }
-      const contentType = String(req.headers['content-type'] || '');
-      if (!contentType.includes('application/json')) {
-        res.writeHead(415, {
-          'Content-Type': 'application/json',
-          'Cache-Control': 'no-store',
-        });
-        res.end(JSON.stringify({
-          jsonrpc: '2.0',
-          error: {
-            code: -32000,
-            message: 'Unsupported Media Type: Content-Type must be application/json',
-          },
-          id: null,
-        }));
-        return;
-      }
-      let rawBody;
-      try {
-        rawBody = await readRequestBody(req);
-        initialParsedBody = JSON.parse(rawBody);
-      } catch (err) {
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          jsonrpc: '2.0',
-          error: { code: -32700, message: 'Parse error', data: String(err) },
-          id: null,
-        }));
-        return;
-      }
-      if (
-        !isInitializeRequest(initialParsedBody)
-      ) {
-        res.writeHead(400, {
-          'Content-Type': 'application/json',
-          'Cache-Control': 'no-store',
-        });
-        res.end(JSON.stringify({
-          jsonrpc: '2.0',
-          error: { code: -32600, message: 'Invalid MCP initialize request.' },
-          id: initialParsedBody?.id ?? null,
-        }));
-        return;
-      }
-
-      authFirstSessionId = randomUUID();
-      touchSession(authFirstSessionId);
-      pinSessionResource(authFirstSessionId, requestedMcpResource);
-      pinSessionOAuthIdentity(
-        authFirstSessionId,
-        authFirstAuthorization.verification.identity,
-      );
-    }
-
-    let transport = null;
-    try {
-      transport = installCanonicalSecuritySchemeProjection(
-        new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => authFirstSessionId ?? randomUUID(),
-        onsessioninitialized: (sid) => {
-          touchSession(sid);
-          pinSessionResource(sid, requestedMcpResource);
-          transports.set(sid, transport);
-          if (authFirstAuthorization) {
-            pinSessionOAuthIdentity(sid, authFirstAuthorization.verification.identity);
-          }
-          if (incomingBinding) {
-            userBindings.set(sid, incomingBinding);
-            markSessionAccountBound(sid);
-            console.log(
-              `[open-mcp] session created ref=${logRef(sid)} `
-              + `(active: ${transports.size}) userRef=${logRef(incomingBinding.userId)}`,
-            );
-          } else {
-            console.log(
-              `[open-mcp] session created ref=${logRef(sid)} (active: ${transports.size})`,
-            );
-          }
-        },
-        }),
-      );
-
-      transport.onclose = () => {
-        const sid = transport.sessionId;
-        if (sid) {
-          transports.delete(sid);
-          userBindings.delete(sid);
-          sessionMeta.delete(sid);
+    const transport = installCanonicalSecuritySchemeProjection(
+      new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sid) => {
+        touchSession(sid);
+        pinSessionResource(sid, requestedMcpResource);
+        transports.set(sid, transport);
+        if (incomingBinding) {
+          userBindings.set(sid, incomingBinding);
+          markSessionAccountBound(sid);
           console.log(
-            `[open-mcp] session closed ref=${logRef(sid)} (active: ${transports.size})`,
+            `[open-mcp] session created ref=${logRef(sid)} `
+            + `(active: ${transports.size}) userRef=${logRef(incomingBinding.userId)}`,
+          );
+        } else {
+          console.log(
+            `[open-mcp] session created ref=${logRef(sid)} (active: ${transports.size})`,
           );
         }
-      };
+      },
+      }),
+    );
 
-      const mcpServer = createOpenMcpServer();
-      await mcpServer.connect(transport);
-      if (authFirstAuthorization) {
-        const seeded = await seedOAuthVaultBinding(
-          authFirstAuthorization.bearer,
-          authFirstAuthorization.verification.payload,
-          authFirstAuthorization.verification.identity,
-          authFirstSessionId,
+    transport.onclose = () => {
+      const sid = transport.sessionId;
+      if (sid) {
+        transports.delete(sid);
+        userBindings.delete(sid);
+        sessionMeta.delete(sid);
+        console.log(
+          `[open-mcp] session closed ref=${logRef(sid)} (active: ${transports.size})`,
         );
-        if (!seeded) {
-          try {
-            await transport.close();
-          } catch {
-            // The maps below remain the authoritative cleanup path.
-          }
-          transports.delete(authFirstSessionId);
-          userBindings.delete(authFirstSessionId);
-          sessionMeta.delete(authFirstSessionId);
-          res.writeHead(503, {
-            'Content-Type': 'application/json',
-            'Cache-Control': 'no-store',
-            'Retry-After': '1',
-          });
-          res.end(JSON.stringify({
-            jsonrpc: '2.0',
-            error: { code: -32603, message: 'Authorization is temporarily unavailable. Retry.' },
-            id: initialParsedBody?.id ?? null,
-          }));
-          return;
-        }
       }
-      await transport.handleRequest(req, res, initialParsedBody);
-      // Exchange the presented link token for a vault binding on the freshly
-      // created session — response is already written, and the client must
-      // receive it before any tool call arrives, so the binding lands first.
-      if (!authFirstEntrance && linkToken && transport.sessionId) {
-        await bindLinkTokenToSession(linkToken, transport.sessionId);
-      }
-      return;
-    } catch (error) {
-      if (!authFirstSessionId) throw error;
-      const provisionalSessionId = transport?.sessionId ?? authFirstSessionId;
-      try {
-        await transport?.close();
-      } catch {
-        // The maps below remain the authoritative cleanup path.
-      }
-      transports.delete(provisionalSessionId);
-      userBindings.delete(provisionalSessionId);
-      sessionMeta.delete(provisionalSessionId);
-      console.warn(
-        `[open-mcp] auth-first initialization failed (${safeErrorLabel(error)})`,
-      );
-      if (!res.headersSent) {
-        res.writeHead(503, {
-          'Content-Type': 'application/json',
-          'Cache-Control': 'no-store',
-          'Retry-After': '1',
-        });
-        res.end(JSON.stringify({
-          jsonrpc: '2.0',
-          error: { code: -32603, message: 'Authorization is temporarily unavailable. Retry.' },
-          id: initialParsedBody?.id ?? null,
-        }));
-      } else if (!res.writableEnded) {
-        res.destroy();
-      }
-      return;
+    };
+
+    const mcpServer = createOpenMcpServer();
+    await mcpServer.connect(transport);
+    await transport.handleRequest(req, res);
+    // Exchange the presented link token for a vault binding on the freshly
+    // created session — response is already written, and the client must
+    // receive it before any tool call arrives, so the binding lands first.
+    if (linkToken && transport.sessionId) {
+      await bindLinkTokenToSession(linkToken, transport.sessionId);
     }
+    return;
   }
 
   // ─── DELETE: close session ──────────────────────────────────────────

--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -16,15 +16,15 @@
     },
     "integratedApiRelease": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "bd3e938eb69909d67324bcb385cff0ca023e9f33",
-      "tree": "6ea4387feebfed64bd77cdb777cfe40e070300f5",
+      "commit": "ce4ec87252fa5296286106c21bbc2a81c79970e8",
+      "tree": "b1ced6204f6981a05667ef65f0ff4794c3a18bf1",
       "governedContractCommit": "fa0701b67625911b8ec97a5399f62ec97a69f976",
       "governedContractTree": "dcee95df1d92018b8fcd8b43645fe63211383274"
     },
     "portfolioProjection": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "bd3e938eb69909d67324bcb385cff0ca023e9f33",
-      "tree": "6ea4387feebfed64bd77cdb777cfe40e070300f5",
+      "commit": "ce4ec87252fa5296286106c21bbc2a81c79970e8",
+      "tree": "b1ced6204f6981a05667ef65f0ff4794c3a18bf1",
       "sourcePaths": [
         "src/portfolio/approvedActionTargets.ts",
         "src/routes/passkeyMcpBinding.ts",
@@ -489,7 +489,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-marketplace-search-23910bce",
+          "resourceUri": "ui://dexter/x402-marketplace-search-0b654c9b",
           "visibility": [
             "model",
             "app"
@@ -509,8 +509,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-marketplace-search-23910bce",
-        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-23910bce",
+        "ui/resourceUri": "ui://dexter/x402-marketplace-search-0b654c9b",
+        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-0b654c9b",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": true,
         "openai/widgetDomain": "https://dexter.cash",
@@ -774,7 +774,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-pricing-95890725",
+          "resourceUri": "ui://dexter/x402-pricing-259bfcd0",
           "visibility": [
             "model",
             "app"
@@ -792,8 +792,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-pricing-95890725",
-        "openai/outputTemplate": "ui://dexter/x402-pricing-95890725",
+        "ui/resourceUri": "ui://dexter/x402-pricing-259bfcd0",
+        "openai/outputTemplate": "ui://dexter/x402-pricing-259bfcd0",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": true,
         "openai/widgetDomain": "https://dexter.cash",
@@ -959,7 +959,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-fetch-result-af524c99",
+          "resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
           "visibility": [
             "model",
             "app"
@@ -978,8 +978,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-fetch-result-af524c99",
-        "openai/outputTemplate": "ui://dexter/x402-fetch-result-af524c99",
+        "ui/resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
+        "openai/outputTemplate": "ui://dexter/x402-fetch-result-8996d1b0",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": false,
         "openai/widgetDomain": "https://dexter.cash",
@@ -1385,7 +1385,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-fetch-result-af524c99",
+          "resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
           "visibility": [
             "model"
           ],
@@ -1403,8 +1403,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-fetch-result-af524c99",
-        "openai/outputTemplate": "ui://dexter/x402-fetch-result-af524c99",
+        "ui/resourceUri": "ui://dexter/x402-fetch-result-8996d1b0",
+        "openai/outputTemplate": "ui://dexter/x402-fetch-result-8996d1b0",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": false,
         "openai/widgetDomain": "https://dexter.cash",
@@ -1693,7 +1693,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-wallet-3760bc3b",
+          "resourceUri": "ui://dexter/x402-wallet-e33931ca",
           "visibility": [
             "model",
             "app"
@@ -1714,8 +1714,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-wallet-3760bc3b",
-        "openai/outputTemplate": "ui://dexter/x402-wallet-3760bc3b",
+        "ui/resourceUri": "ui://dexter/x402-wallet-e33931ca",
+        "openai/outputTemplate": "ui://dexter/x402-wallet-e33931ca",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": false,
         "openai/widgetDomain": "https://dexter.cash",

--- a/release/opendexter-accepted-production.json
+++ b/release/opendexter-accepted-production.json
@@ -4,12 +4,12 @@
   "api": {
     "endpoint": "https://api.dexter.cash/health",
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "releaseId": "bd3e938eb699-582bad68f7f76982-4297dbe748e0",
-    "sourceCommit": "bd3e938eb69909d67324bcb385cff0ca023e9f33",
-    "sourceTree": "6ea4387feebfed64bd77cdb777cfe40e070300f5",
-    "toolingCommit": "bd3e938eb69909d67324bcb385cff0ca023e9f33",
-    "artifactSha256": "582bad68f7f76982df59ba831f2e696dc132a67c76625bd9ec4c8f9503240e7a",
-    "metadataBindingSha256": "50a87e656244cb7b2051eb205f0bc3292d5b770496da296e5c74ae177be82f06"
+    "releaseId": "ce4ec87252fa-81054568dfaf946f-4297dbe748e0",
+    "sourceCommit": "ce4ec87252fa5296286106c21bbc2a81c79970e8",
+    "sourceTree": "b1ced6204f6981a05667ef65f0ff4794c3a18bf1",
+    "toolingCommit": "ce4ec87252fa5296286106c21bbc2a81c79970e8",
+    "artifactSha256": "81054568dfaf946f77205bf7e60a64bbf7b080d56fe3ca6126fa2f51f7ca3259",
+    "metadataBindingSha256": "366279da97c673e4b218b4b9fe48541a296efc3fdd3d2e4f79e55efb205cbbb4"
   },
   "facilitator": {
     "endpoint": "https://x402.dexter.cash/version",

--- a/release/opendexter-source-contracts.json
+++ b/release/opendexter-source-contracts.json
@@ -13,15 +13,15 @@
   },
   "integratedApiRelease": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "bd3e938eb69909d67324bcb385cff0ca023e9f33",
-    "tree": "6ea4387feebfed64bd77cdb777cfe40e070300f5",
+    "commit": "ce4ec87252fa5296286106c21bbc2a81c79970e8",
+    "tree": "b1ced6204f6981a05667ef65f0ff4794c3a18bf1",
     "governedContractCommit": "fa0701b67625911b8ec97a5399f62ec97a69f976",
     "governedContractTree": "dcee95df1d92018b8fcd8b43645fe63211383274"
   },
   "portfolioProjection": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "bd3e938eb69909d67324bcb385cff0ca023e9f33",
-    "tree": "6ea4387feebfed64bd77cdb777cfe40e070300f5",
+    "commit": "ce4ec87252fa5296286106c21bbc2a81c79970e8",
+    "tree": "b1ced6204f6981a05667ef65f0ff4794c3a18bf1",
     "sourcePaths": [
       "src/portfolio/approvedActionTargets.ts",
       "src/routes/passkeyMcpBinding.ts",

--- a/tests/open-mcp-manifest.test.mjs
+++ b/tests/open-mcp-manifest.test.mjs
@@ -8,8 +8,6 @@ import {
   OPEN_TOOL_NAMES,
 } from '../lib/open-tool-contracts.mjs';
 import {
-  OPEN_MCP_AUTH_FIRST_PRM_URL,
-  OPEN_MCP_AUTH_FIRST_RESOURCE,
   OPEN_MCP_AUTHORIZATION_SERVER,
   OPEN_MCP_AUTHORIZATION_SERVER_METADATA,
   OPEN_MCP_PRM,
@@ -23,17 +21,8 @@ test('well-known manifest advertises the cumulative five-to-twelve OAuth contrac
   assert.equal(manifest.name, 'OpenDexter');
   assert.equal(manifest.namespace, 'opendexter');
   assert.equal(manifest.url, OPEN_MCP_VAULT_AUDIENCE);
-  assert.deepEqual(manifest.endpoints, {
-    public: OPEN_MCP_VAULT_AUDIENCE,
-    vault: OPEN_MCP_AUTH_FIRST_RESOURCE,
-  });
   assert.equal(manifest.auth.protectedResourceMetadata, OPEN_MCP_PRM_URL);
   assert.equal(manifest.auth.authorizationServer, OPEN_MCP_AUTHORIZATION_SERVER);
-  assert.deepEqual(manifest.auth.alwaysProtected, {
-    resource: OPEN_MCP_AUTH_FIRST_RESOURCE,
-    protectedResourceMetadata: OPEN_MCP_AUTH_FIRST_PRM_URL,
-    scope: 'vault',
-  });
   assert.deepEqual(OPEN_MCP_PRM.scopes_supported, ['vault']);
   assert.deepEqual(
     buildOpenMcpAuthorizationServerMetadata(

--- a/tests/open-roster-http.test.mjs
+++ b/tests/open-roster-http.test.mjs
@@ -17,10 +17,6 @@ import {
   OPEN_TOOL_NAMES,
 } from '../lib/open-tool-contracts.mjs';
 import {
-  AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
-  OPEN_MCP_AUTH_FIRST_PRM,
-  OPEN_MCP_AUTH_FIRST_PRM_URL,
-  OPEN_MCP_AUTH_FIRST_RESOURCE,
   OPEN_MCP_VAULT_AUDIENCE,
   VAULT_WWW_AUTHENTICATE,
   buildVaultWwwAuthenticate,
@@ -82,7 +78,7 @@ async function stopChild(child) {
   if (child.exitCode === null) child.kill('SIGKILL');
 }
 
-test('mixed HTTP discovery stays public while the exact vault resource authenticates before initialization', async () => {
+test('HTTP discovery lists five anonymously and twelve immediately after Bearer initialization', async () => {
   const { privateKey, publicKey } = await generateKeyPair('ES256');
   const publicJwk = await exportJWK(publicKey);
   Object.assign(publicJwk, {
@@ -91,53 +87,19 @@ test('mixed HTTP discovery stays public while the exact vault resource authentic
     use: 'sig',
   });
   const now = Math.floor(Date.now() / 1_000);
-  const authFirstToken = await new SignJWT({
+  const token = await new SignJWT({
     scope: 'vault',
     dexter_surface: 'a'.repeat(64),
   })
     .setProtectedHeader({ alg: 'ES256', kid: publicJwk.kid })
     .setIssuer('https://dexter.cash')
-    .setAudience(OPEN_MCP_AUTH_FIRST_RESOURCE)
-    .setSubject('opendexter-roster-test-user')
-    .setIssuedAt(now)
-    .setExpirationTime(now + 300)
-    .sign(privateKey);
-  const authFirstOtherIdentityToken = await new SignJWT({
-    scope: 'vault',
-    dexter_surface: 'd'.repeat(64),
-  })
-    .setProtectedHeader({ alg: 'ES256', kid: publicJwk.kid })
-    .setIssuer('https://dexter.cash')
-    .setAudience(OPEN_MCP_AUTH_FIRST_RESOURCE)
-    .setSubject('opendexter-other-roster-test-user')
-    .setIssuedAt(now)
-    .setExpirationTime(now + 300)
-    .sign(privateKey);
-  const canonicalToken = await new SignJWT({
-    scope: 'vault',
-    dexter_surface: 'b'.repeat(64),
-  })
-    .setProtectedHeader({ alg: 'ES256', kid: publicJwk.kid })
-    .setIssuer('https://dexter.cash')
     .setAudience(OPEN_MCP_VAULT_AUDIENCE)
-    .setSubject('opendexter-wrong-resource-test-user')
-    .setIssuedAt(now)
-    .setExpirationTime(now + 300)
-    .sign(privateKey);
-  const seedFailureToken = await new SignJWT({
-    scope: 'vault',
-    dexter_surface: 'c'.repeat(64),
-  })
-    .setProtectedHeader({ alg: 'ES256', kid: publicJwk.kid })
-    .setIssuer('https://dexter.cash')
-    .setAudience(OPEN_MCP_AUTH_FIRST_RESOURCE)
-    .setSubject('opendexter-seed-failure-test-user')
+    .setSubject('opendexter-roster-test-user')
     .setIssuedAt(now)
     .setExpirationTime(now + 300)
     .sign(privateKey);
 
   let seedCalls = 0;
-  let failedSeedCalls = 0;
   let seedCompleted = false;
   const dependencyServer = createHttpServer(async (request, response) => {
     try {
@@ -154,18 +116,10 @@ test('mixed HTTP discovery stays public while the exact vault resource authentic
         request.method === 'POST'
         && url.pathname === '/api/passkey-vault/pair/oauth-seed'
       ) {
-        let rawBody = '';
-        for await (const chunk of request) {
-          rawBody += chunk;
-        }
-        const body = JSON.parse(rawBody);
-        if (body.access_token === seedFailureToken) {
-          failedSeedCalls += 1;
-          response.writeHead(503, { 'content-type': 'application/json' });
-          response.end(JSON.stringify({ ok: false }));
-          return;
-        }
         seedCalls += 1;
+        for await (const _chunk of request) {
+          // Consume the body before delaying the response.
+        }
         await new Promise((resolve) => setTimeout(resolve, 150));
         seedCompleted = true;
         response.writeHead(200, { 'content-type': 'application/json' });
@@ -207,152 +161,32 @@ test('mixed HTTP discovery stays public while the exact vault resource authentic
   child.stderr.on('data', (chunk) => { output.text += chunk; });
 
   let anonymousClient = null;
-  let anonymousTransport = null;
   let authenticatedClient = null;
-  let authenticatedTransport = null;
   try {
     await waitForStartup(child, openMcpPort, output);
     const mcpUrl = new URL(`http://127.0.0.1:${openMcpPort}/mcp`);
-    const vaultUrl = new URL(`http://127.0.0.1:${openMcpPort}/mcp/vault`);
-
-    const vaultMetadata = await fetch(
-      `http://127.0.0.1:${openMcpPort}/.well-known/oauth-protected-resource/mcp/vault`,
-    );
-    assert.equal(vaultMetadata.status, 200);
-    assert.deepEqual(await vaultMetadata.json(), OPEN_MCP_AUTH_FIRST_PRM);
-
-    const initializeBody = JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'initialize',
-      params: {
-        protocolVersion: '2025-06-18',
-        capabilities: {},
-        clientInfo: { name: 'auth-first-roster-probe', version: '1.0.0' },
-      },
-    });
-    const unauthenticatedInitialize = await fetch(vaultUrl, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json, text/event-stream',
-        'Content-Type': 'application/json',
-      },
-      body: initializeBody,
-    });
-    assert.equal(unauthenticatedInitialize.status, 401);
-    assert.equal(
-      unauthenticatedInitialize.headers.get('www-authenticate'),
-      AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
-    );
-    assert.match(
-      unauthenticatedInitialize.headers.get('access-control-expose-headers') || '',
-      /WWW-Authenticate/i,
-    );
-
-    const wrongAudienceInitialize = await fetch(vaultUrl, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json, text/event-stream',
-        Authorization: `Bearer ${canonicalToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: initializeBody,
-    });
-    assert.equal(wrongAudienceInitialize.status, 401);
-    assert.equal(
-      wrongAudienceInitialize.headers.get('www-authenticate'),
-      buildVaultWwwAuthenticate({
-        error: 'invalid_token',
-        errorDescription: 'Connect OpenDexter with a valid vault authorization to continue',
-        resourceMetadataUrl: OPEN_MCP_AUTH_FIRST_PRM_URL,
-      }),
-    );
-
-    const invalidAcceptInitialize = await fetch(vaultUrl, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        Authorization: `Bearer ${authFirstToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: initializeBody,
-    });
-    assert.equal(invalidAcceptInitialize.status, 406);
-    assert.equal(invalidAcceptInitialize.headers.get('mcp-session-id'), null);
-    assert.equal(seedCalls, 0);
-    assert.equal(failedSeedCalls, 0);
-
-    const invalidContentTypeInitialize = await fetch(vaultUrl, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json, text/event-stream',
-        Authorization: `Bearer ${authFirstToken}`,
-        'Content-Type': 'text/plain',
-      },
-      body: initializeBody,
-    });
-    assert.equal(invalidContentTypeInitialize.status, 415);
-    assert.equal(invalidContentTypeInitialize.headers.get('mcp-session-id'), null);
-    assert.equal(seedCalls, 0);
-    assert.equal(failedSeedCalls, 0);
-
-    const malformedInitialize = await fetch(vaultUrl, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json, text/event-stream',
-        Authorization: `Bearer ${authFirstToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 2,
-        method: 'initialize',
-        params: {},
-      }),
-    });
-    assert.equal(malformedInitialize.status, 400);
-    assert.equal(malformedInitialize.headers.get('mcp-session-id'), null);
-    assert.equal(seedCalls, 0);
-    assert.equal(failedSeedCalls, 0);
-
-    const unavailableSeed = await fetch(vaultUrl, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json, text/event-stream',
-        Authorization: `Bearer ${seedFailureToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: initializeBody,
-    });
-    assert.equal(unavailableSeed.status, 503);
-    assert.equal(unavailableSeed.headers.get('mcp-session-id'), null);
-    assert.equal(unavailableSeed.headers.get('retry-after'), '1');
-    assert.equal(seedCalls, 0);
-    assert.equal(failedSeedCalls, 1);
 
     anonymousClient = new Client({
       name: 'anonymous-roster-test',
       version: '1.0.0',
     });
-    anonymousTransport = new StreamableHTTPClientTransport(mcpUrl);
-    await anonymousClient.connect(anonymousTransport);
-    assert.ok(anonymousTransport.sessionId);
+    await anonymousClient.connect(new StreamableHTTPClientTransport(mcpUrl));
     assert.deepEqual(
       (await anonymousClient.listTools()).tools.map(({ name }) => name),
       OPEN_ANONYMOUS_TOOL_NAMES,
     );
+    await closeClient(anonymousClient);
+    anonymousClient = null;
 
     authenticatedClient = new Client({
       name: 'authenticated-roster-test',
       version: '1.0.0',
     });
-    authenticatedTransport = new StreamableHTTPClientTransport(vaultUrl, {
+    await authenticatedClient.connect(new StreamableHTTPClientTransport(mcpUrl, {
       requestInit: {
-        headers: { Authorization: `Bearer ${authFirstToken}` },
+        headers: { Authorization: `Bearer ${token}` },
       },
-    });
-    await authenticatedClient.connect(authenticatedTransport);
-    assert.ok(authenticatedTransport.sessionId);
+    }));
 
     const authenticatedTools = await authenticatedClient.listTools();
     assert.equal(seedCompleted, true, 'tools/list returned before vault binding completed');
@@ -361,116 +195,6 @@ test('mixed HTTP discovery stays public while the exact vault resource authentic
       authenticatedTools.tools.map(({ name }) => name),
       OPEN_TOOL_NAMES,
     );
-
-    const otherIdentityOnSession = await fetch(vaultUrl, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json, text/event-stream',
-        Authorization: `Bearer ${authFirstOtherIdentityToken}`,
-        'Content-Type': 'application/json',
-        'MCP-Protocol-Version': '2025-06-18',
-        'mcp-session-id': authenticatedTransport.sessionId,
-      },
-      body: JSON.stringify({ jsonrpc: '2.0', id: 90, method: 'tools/list', params: {} }),
-    });
-    assert.equal(otherIdentityOnSession.status, 401);
-    assert.match(
-      otherIdentityOnSession.headers.get('www-authenticate') || '',
-      /error="invalid_token"/,
-    );
-    assert.deepEqual(
-      (await authenticatedClient.listTools()).tools.map(({ name }) => name),
-      OPEN_TOOL_NAMES,
-    );
-    assert.equal(seedCalls, 1, 'foreign identity forced a vault reseed');
-
-    const crossRouteRequest = async ({
-      url,
-      sessionId,
-      method,
-      authorization = null,
-    }) => fetch(url, {
-      method,
-      headers: {
-        Accept: 'application/json, text/event-stream',
-        ...(authorization ? { Authorization: `Bearer ${authorization}` } : {}),
-        'MCP-Protocol-Version': '2025-06-18',
-        'mcp-session-id': sessionId,
-        ...(method === 'POST' ? { 'Content-Type': 'application/json' } : {}),
-      },
-      ...(method === 'POST'
-        ? {
-            body: JSON.stringify({
-              jsonrpc: '2.0',
-              id: 91,
-              method: 'tools/list',
-              params: {},
-            }),
-          }
-        : {}),
-    });
-
-    const unauthenticatedCanonicalSessionProbe = await crossRouteRequest({
-      url: vaultUrl,
-      sessionId: anonymousTransport.sessionId,
-      method: 'POST',
-    });
-    assert.equal(unauthenticatedCanonicalSessionProbe.status, 401);
-    assert.equal(
-      unauthenticatedCanonicalSessionProbe.headers.get('www-authenticate'),
-      AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
-    );
-
-    for (const method of ['POST', 'GET', 'DELETE']) {
-      const canonicalSessionOnVault = await crossRouteRequest({
-        url: vaultUrl,
-        sessionId: anonymousTransport.sessionId,
-        method,
-        authorization: authFirstToken,
-      });
-      assert.equal(canonicalSessionOnVault.status, 404, method);
-
-      const vaultSessionOnCanonical = await crossRouteRequest({
-        url: mcpUrl,
-        sessionId: authenticatedTransport.sessionId,
-        method,
-      });
-      assert.equal(vaultSessionOnCanonical.status, 404, method);
-    }
-    assert.equal(seedCalls, 1, 'cross-resource requests mutated the vault binding');
-    assert.deepEqual(
-      (await anonymousClient.listTools()).tools.map(({ name }) => name),
-      OPEN_ANONYMOUS_TOOL_NAMES,
-    );
-    assert.deepEqual(
-      (await authenticatedClient.listTools()).tools.map(({ name }) => name),
-      OPEN_TOOL_NAMES,
-    );
-
-    for (const method of ['POST', 'GET', 'DELETE']) {
-      const missingSessionBearer = await crossRouteRequest({
-        url: vaultUrl,
-        sessionId: authenticatedTransport.sessionId,
-        method,
-      });
-      assert.equal(missingSessionBearer.status, 401, method);
-      assert.equal(
-        missingSessionBearer.headers.get('www-authenticate'),
-        AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
-      );
-    }
-    assert.deepEqual(
-      (await authenticatedClient.listTools()).tools.map(({ name }) => name),
-      OPEN_TOOL_NAMES,
-    );
-
-    const authorizedDelete = await crossRouteRequest({
-      url: vaultUrl,
-      sessionId: authenticatedTransport.sessionId,
-      method: 'DELETE',
-      authorization: authFirstToken,
-    });
-    assert.equal(authorizedDelete.status, 200);
   } finally {
     await closeClient(anonymousClient);
     await closeClient(authenticatedClient);

--- a/tests/open-session-auth-state.test.mjs
+++ b/tests/open-session-auth-state.test.mjs
@@ -32,7 +32,7 @@ const OAUTH_IDENTITY = Object.freeze({
 });
 
 const PUBLIC_RESOURCE = 'https://open.dexter.cash/mcp';
-const VAULT_RESOURCE = 'https://open.dexter.cash/mcp/vault';
+const OTHER_RESOURCE = 'https://other.example/mcp';
 
 test('an MCP session is pinned immutably to its initialization resource', () => {
   const meta = pinOpenSessionResource(
@@ -42,10 +42,10 @@ test('an MCP session is pinned immutably to its initialization resource', () => 
 
   assert.equal(openSessionResourceOf(meta), PUBLIC_RESOURCE);
   assert.equal(openSessionResourceStatus(meta, PUBLIC_RESOURCE), 'match');
-  assert.equal(openSessionResourceStatus(meta, VAULT_RESOURCE), 'mismatch');
+  assert.equal(openSessionResourceStatus(meta, OTHER_RESOURCE), 'mismatch');
   assert.doesNotThrow(() => pinOpenSessionResource(meta, PUBLIC_RESOURCE));
   assert.throws(
-    () => pinOpenSessionResource(meta, VAULT_RESOURCE),
+    () => pinOpenSessionResource(meta, OTHER_RESOURCE),
     /open_session_resource_mismatch/,
   );
 });

--- a/tests/open-tool-auth.test.mjs
+++ b/tests/open-tool-auth.test.mjs
@@ -5,11 +5,6 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import {
-  AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
-  OPEN_MCP_AUTH_FIRST_PRM,
-  OPEN_MCP_AUTH_FIRST_PRM_PATH,
-  OPEN_MCP_AUTH_FIRST_PRM_URL,
-  OPEN_MCP_AUTH_FIRST_RESOURCE,
   OPEN_MCP_AUTHORIZATION_SERVER,
   OPEN_MCP_AUTHORIZATION_SERVER_METADATA,
   OPEN_MCP_CHALLENGE_REQUIRED_PARAMETERS,
@@ -31,7 +26,6 @@ import {
   projectCanonicalSecuritySchemes,
   projectCanonicalSecuritySchemesOnMessage,
   registerOpenTool,
-  openMcpProtectedResourceMetadataForPath,
   vaultAuthenticationReason,
   vaultAuthenticationResult,
   withOpenToolAuth,
@@ -290,32 +284,14 @@ test('OpenDexter authorization metadata helper excludes both legacy discovery ra
   );
 });
 
-test('mixed and OAuth-first metadata routes serve exact resource identifiers', () => {
+test('both protected-resource metadata routes serve the same corrected issuer', () => {
   for (const pathname of [
     '/.well-known/oauth-protected-resource',
     '/.well-known/oauth-protected-resource/mcp',
   ]) {
     assert.equal(isOpenMcpProtectedResourceMetadataPath(pathname), true);
     assert.deepEqual(OPEN_MCP_PRM.authorization_servers, ['https://mcp.dexter.cash/mcp']);
-    assert.equal(openMcpProtectedResourceMetadataForPath(pathname), OPEN_MCP_PRM);
   }
-  assert.equal(
-    openMcpProtectedResourceMetadataForPath(
-      OPEN_MCP_AUTH_FIRST_PRM_PATH,
-    ),
-    OPEN_MCP_AUTH_FIRST_PRM,
-  );
-  assert.equal(OPEN_MCP_AUTH_FIRST_PRM.resource, OPEN_MCP_AUTH_FIRST_RESOURCE);
-  assert.deepEqual(
-    OPEN_MCP_AUTH_FIRST_PRM.authorization_servers,
-    ['https://mcp.dexter.cash/mcp'],
-  );
-  assert.equal(
-    isOpenMcpProtectedResourceMetadataPath(
-      OPEN_MCP_AUTH_FIRST_PRM_PATH,
-    ),
-    true,
-  );
   assert.equal(
     isOpenMcpProtectedResourceMetadataPath('/mcp/.well-known/oauth-protected-resource'),
     false,
@@ -339,10 +315,6 @@ test('runtime challenge is host-native and contains no legacy pairing path', () 
   assert.deepEqual(result.structuredContent, data);
   assert.deepEqual(result._meta['mcp/www_authenticate'], [VAULT_WWW_AUTHENTICATE]);
   assert.match(VAULT_WWW_AUTHENTICATE, new RegExp(`resource_metadata="${OPEN_MCP_PRM_URL}"`));
-  assert.match(
-    AUTH_FIRST_VAULT_WWW_AUTHENTICATE,
-    new RegExp(`resource_metadata="${OPEN_MCP_AUTH_FIRST_PRM_URL}"`),
-  );
   assert.match(VAULT_WWW_AUTHENTICATE, /scope="vault"/);
   assert.doesNotMatch(VAULT_WWW_AUTHENTICATE, /error=/);
   assert.doesNotMatch(VAULT_WWW_AUTHENTICATE, /error_description=/);

--- a/tests/open-vault-oauth.test.mjs
+++ b/tests/open-vault-oauth.test.mjs
@@ -70,7 +70,7 @@ test('accepts vault among multiple space-delimited scopes', async () => {
 
 test('rejects a multi-audience token even when the exact resource is included', async () => {
   const result = await verify(await token({
-    audience: [AUDIENCE, 'https://open.dexter.cash/mcp/vault'],
+    audience: [AUDIENCE, 'https://other.example/mcp'],
   }));
   assert.deepEqual(result, {
     ok: false,


### PR DESCRIPTION
Removes the alternate /mcp/vault entrypoint and restores one standards-based mixed-auth OpenDexter server at https://open.dexter.cash/mcp. Public discovery works before sign-in; wallet, portfolio, payment, and governed action tools challenge for OAuth when invoked.

The accepted-production receipt is pinned to deployed API commit ce4ec872 and the existing facilitator release.

Verification:
- focused MCP/OAuth suite: 54 passed
- generated descriptor frozen from accepted production
- retired route/source references: zero
- Dexter anti-slop gate: passed on changed outward copy