### PR TITLE
fix: unstick Indexter discovery transport

### DIFF
--- a/open-mcp-server.mjs
+++ b/open-mcp-server.mjs
@@ -512,10 +512,17 @@ async function indexterDiscover({
     response = await fetchInternalApi(
       `${INDEXTER_DISCOVERY_PATH}?${searchParams.toString()}`,
       {
-        headers: { accept: 'application/json' },
+        // The x402 edge has emitted a malformed gzip representation for this
+        // JSON route: headers arrive, but Node cannot finish decoding the body.
+        // Discovery needs deterministic bounded reads, so request the original
+        // bytes instead of negotiating compression.
+        headers: {
+          accept: 'application/json',
+          'accept-encoding': 'identity',
+        },
         signal: AbortSignal.timeout(10_000),
       },
-      { origin: DEXTER_API },
+      { origin: API_BASE_FALLBACK },
     );
     payload = await response.json();
   } catch (error) {

--- a/tests/indexter-discovery-contract.test.mjs
+++ b/tests/indexter-discovery-contract.test.mjs
@@ -8,6 +8,7 @@ import {
   OPEN_TOOL_CONTRACTS,
   OPEN_TOOL_NAMES,
 } from '../lib/open-tool-contracts.mjs';
+import { resolveInternalApiOrigin } from '../lib/internal-api-fetch.mjs';
 import { createOpenMcpServer } from '../open-mcp-server.mjs';
 
 const OBSERVED_AT = '2026-09-04T02:30:00.000Z';
@@ -145,9 +146,11 @@ async function connectedOpenClient(t, name) {
 test('broad discovery calls the overview endpoint exactly once without a wallet read', async (t) => {
   const previousFetch = globalThis.fetch;
   const requests = [];
-  globalThis.fetch = async (input) => {
+  const requestHeaders = [];
+  globalThis.fetch = async (input, init = {}) => {
     const url = new URL(String(input));
     requests.push(url);
+    requestHeaders.push(new Headers(init.headers));
     return new Response(JSON.stringify(discoveryPayload()), {
       status: 200,
       headers: { 'content-type': 'application/json' },
@@ -164,11 +167,14 @@ test('broad discovery calls the overview endpoint exactly once without a wallet 
   });
 
   assert.equal(requests.length, 1);
+  assert.equal(requests[0].origin, resolveInternalApiOrigin(process.env));
   assert.equal(requests[0].pathname, '/api/x402gle/indexter/discovery');
   assert.equal(requests[0].searchParams.get('mode'), 'overview');
   assert.equal(requests[0].searchParams.get('provider'), null);
   assert.equal(requests[0].searchParams.get('limit'), null);
   assert.equal(requests[0].searchParams.get('capabilityPageSize'), null);
+  assert.equal(requestHeaders[0].get('accept'), 'application/json');
+  assert.equal(requestHeaders[0].get('accept-encoding'), 'identity');
   assert.equal(requests.some(({ pathname }) => pathname.includes('wallet')), false);
   assert.notEqual(result.isError, true, JSON.stringify(result, null, 2));
   assert.match(result.structuredContent.discoveryResultSetId, /^[0-9a-f-]{36}$/i);


### PR DESCRIPTION
Routes Indexter discovery through the configured Dexter API origin instead of the x402 facilitator fallback, and requests identity encoding to prevent malformed edge compression from stranding the response body. Adds regression coverage for both the API origin and encoding header.\n\nProof: focused discovery and hosted MCP contract suites pass; live transport diagnosis reproduced the malformed gzip response and verified the corrected request completes with valid JSON. No wallet or payment path changes.